### PR TITLE
Join array of shas and pass that as the query param

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import getSHAArray from "./utils/getSHAArray";
 import setLoggedIn from "./utils/vscode/setLoggedIn";
 import getLocalUser from "./utils/vscode/getLocalUser";
 import getRepoInfo from "./utils/vscode/getRepoInfo";
+import { join } from "path";
 
 
 // repo information
@@ -78,10 +79,18 @@ function getPRsPerSHAs() {
   watermelonPanel.currentPanel?.doRefactor({
     command: "loading",
   });
+
+  // Splice the array to avoid the 256 character restriction on the query to the GitHub API
+  if (arrayOfSHAs.length > 22) {
+    arrayOfSHAs.splice(22, arrayOfSHAs.length - 22);
+  }
+
+  let joinedArrayOfSHAs = arrayOfSHAs.join();
+
   octokit
     .request(`GET /search/issues?type=Commits`, {
       org: owner,
-      q: `hash:${arrayOfSHAs[0]}`,
+      q: joinedArrayOfSHAs,
     })
     .then((octorespSearch: any) => {
       const issuesBySHAs = octorespSearch.data.items;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,11 +80,7 @@ function getPRsPerSHAs() {
     command: "loading",
   });
 
-  // Splice the array to avoid the 256 character restriction on the query to the GitHub API
-  if (arrayOfSHAs.length > 22) {
-    arrayOfSHAs.splice(22, arrayOfSHAs.length - 22);
-  }
-
+  arrayOfSHAs = arrayOfSHAs.slice(0, 22);
   let joinedArrayOfSHAs = arrayOfSHAs.join();
 
   octokit


### PR DESCRIPTION
## Description

Previously, we were only passing 1 SHA as the query parameter to the GitHub API when searching for commits based on SHAs. This was limiting the number of results we were showing. With this fix, we now have multiple search results. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)