### PR TITLE
multiple shas

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   function getPRsPerSHAs() {
-    arrayOfSHAs = arrayOfSHAs.slice(0, 22);
+    // takes the first 22 shas and creates a list to send to the gh api
     let joinedArrayOfSHAs = arrayOfSHAs.slice(0,22).join();
   
     octokit

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,11 +81,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   function getPRsPerSHAs() {
+    arrayOfSHAs = arrayOfSHAs.slice(0, 22);
+    let joinedArrayOfSHAs = arrayOfSHAs.join();
+  
     octokit
       .request(`GET /search/issues?type=Commits`, {
         org: owner,
-        q: `hash:${arrayOfSHAs[0]}`,
-      })
+        q: joinedArrayOfSHAs,
+      })    
       .then((octorespSearch: any) => {
         const issuesBySHAs = octorespSearch.data.items;
         if (issuesBySHAs.length === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   function getPRsPerSHAs() {
     arrayOfSHAs = arrayOfSHAs.slice(0, 22);
-    let joinedArrayOfSHAs = arrayOfSHAs.join();
+    let joinedArrayOfSHAs = arrayOfSHAs.slice(0,22).join();
   
     octokit
       .request(`GET /search/issues?type=Commits`, {


### PR DESCRIPTION
## Description

Previously, we were only passing 1 SHA as the query parameter to the GitHub API when searching for commits based on SHAs. This was limiting the number of results we were showing. With this fix, we now have multiple search results.

Sending this new PR to close #49 which has the merge conflicts uncorrectly done

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)