### PR TITLE
Remove forced colors, add bg to img

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -117,6 +117,3 @@ pre {
   padding: 0.5em 1em;
   margin-bottom: 1em;
 }
-img{
-  background-color:rgba(192,192,192,0.3);
-}

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -8,7 +8,6 @@ code {
 }
 .hljs {
   background-color: rgba(0, 0, 0, 0.4);
-  color: #a7a7a7;
 }
 details > summary {
   padding: 2px 6px;
@@ -26,11 +25,9 @@ details > summary {
 .pr-date {
   font-style: italic;
   opacity: 0.5;
-  color: lightgray;
 }
 .pr-poster {
   font-weight: bold;
-  color: lightgray;
 }
 .comment {
   margin-bottom: 1%;
@@ -119,4 +116,7 @@ pre {
   color: white;
   padding: 0.5em 1em;
   margin-bottom: 1em;
+}
+img{
+  background-color:rgba(192,192,192,0.3);
 }


### PR DESCRIPTION
## Description

On light themes our fonts were hard to read, let it default to the current theme's. 
Lots of room for improvement tho but will work for now.

Closes #126 
## Type of change

- Bug fix (non-breaking change which fixes an issue)
## Previous
![image](https://user-images.githubusercontent.com/11527621/164736429-a0b26857-8b3a-4260-ae69-4219fc8bff49.png)
![image](https://user-images.githubusercontent.com/11527621/164736470-bd9479c9-9bef-477c-931b-a339f3f56037.png)


## Current
![image](https://user-images.githubusercontent.com/11527621/164736183-1587e4d6-9ce1-4f31-9941-203d3d18766b.png)
![image](https://user-images.githubusercontent.com/11527621/164736234-2dfd96bc-dfc9-4b2b-b2c5-a665fb65206f.png)
