### PR TITLE
Add color to a:hover

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -51,6 +51,7 @@ a:visited {
 }
 
 a:hover {
+  color:#ad3838;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Description

Hovered hyperlinks now use the dark red from the Watermelon color palette

<img width="399" alt="Screen Shot 2022-04-23 at 4 12 58 PM" src="https://user-images.githubusercontent.com/8325094/164946137-dfb8ab1d-7733-4b8f-8de6-19f7a993a601.png">


## Type of change

Please delete options that are not relevant or write your own.

- Chore: cleanup/renaming, etc
