### PR TITLE
Added pr header and it's css

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -85,6 +85,7 @@ $(document).ready(function () {
         pr.title
       }</a></summary>
         <div>
+        <div class="pr-header">
           <div class="pr-owner">
             <p class="pr-poster" title="View this user on github">
               Author: <a href="${pr.userLink}">${pr.user}</a>
@@ -98,7 +99,8 @@ $(document).ready(function () {
               })}
             </p>
           </div>
-          <div class="pr-body">
+        </div>
+        <div class="pr-body">
             ${replaceIssueLinks(
               replaceUserTags(marked.parse(pr.body)),
               pr.repo_url

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -17,10 +17,16 @@ details > summary {
   cursor: pointer;
   font-size: large;
 }
+.pr-header{
+  border-radius: 6px 6px 0 0;
+  border: 1px solid #30363d;
+  background-color: #30363d;
+}
 .pr-owner {
   display: flex;
-  width: 100%;
+  padding: 0.2em 0.4em;
   justify-content: space-between;
+  background-color: rgba(56,139,253,0.15);
 }
 .pr-date {
   font-style: italic;
@@ -28,6 +34,11 @@ details > summary {
 }
 .pr-poster {
   font-weight: bold;
+}
+.pr-body {
+  padding: 0.2em 0.4em;
+  border: 1px solid rgba(56,139,253,0.4);
+  border-radius: 0 0 6px 6px;
 }
 .comment {
   margin-bottom: 1%;


### PR DESCRIPTION
## Description

Now differentiates PR header to look more like github's UI

## Type of change

- New feature (non-breaking change which adds functionality)
<img width="594" alt="Screen Shot 2022-04-27 at 4 00 04 PM" src="https://user-images.githubusercontent.com/11527621/165630114-93061e9d-ba9f-4dd4-ab33-05d48041b0a5.png">

