### PR TITLE
Fix/image csp for all of GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixed some instances of the get help on Slack button not working
 - Will select whole file if no selection is made
 - Fixed case where empty PR body or empty comment would break the app
+- Allow all of github as source for images
 
 ## [1.1.3]
 - Fixed some instances of the "Get help on Slack" running search

--- a/src/utils/vscode/getInitialHTML.ts
+++ b/src/utils/vscode/getInitialHTML.ts
@@ -16,8 +16,9 @@ export default function getInitialHTML(
   let imageSources = [
     webview.cspSource,
     "https://uploads-ssl.webflow.com/",
-    "https://cloud.githubusercontent.com/assets/",
-    "https://user-images.githubusercontent.com",
+    "https://*.githubusercontent.com",
+    "https://*.github.com",
+    "https://*.github.io",
     "https://cdn.webflow.com/",
   ];
   let scriptSources = [


### PR DESCRIPTION
## Description
Some instances of CI/CD images were not displayed. 
Relaxed the CSP rules to allow all of github

## Type of change


- Bug fix (non-breaking change which fixes an issue)

