### PR TITLE
Send code explanation within the message that gets sent to m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added Pr Status indicator to titles
 - Added Codecov as an image source to CSP
 - Moved functions out of main file to help with size and DX
+- Explain code block
 
 ## [1.1.4]
 - Added github as an image source to CSP

--- a/media/main.js
+++ b/media/main.js
@@ -51,6 +51,9 @@ $(document).ready(function () {
       "<button class='run-watermelon'>Run Watermelon</button><br/>"
     );
     $("#ghHolder").append(
+      `<p'>${explanation}</p>`
+    );
+    $("#ghHolder").append(
       `<button class='help-link'>Get help from ${authorName}</button>`
     );
     $(".run-watermelon").on("click", (event) => {
@@ -209,6 +212,9 @@ $(document).ready(function () {
       case "author":
         authorName = message.author;
         break;
+      case "explanation":
+        console.log("message.explanation - main.js: ", message.explanation);
+        explanation = message.explanation;
     }
   });
 });

--- a/media/main.js
+++ b/media/main.js
@@ -199,12 +199,12 @@ $(document).ready(function () {
   }
 
   window.addEventListener("message", (event) => {
-    console.log("messge received", event.data.codeExplanation);
+    console.log("messge received", event.data.explanation);
     const message = event.data; // The JSON data our extension sent
     switch (message.command) {
       case "prs":
         removeLoading();
-        addPRsToDoc(message.data, event.data.codeExplanation);
+        addPRsToDoc(message.data, event.data.explanation);
         break;
       case "loading":
         setLoading();

--- a/media/main.js
+++ b/media/main.js
@@ -46,13 +46,12 @@ $(document).ready(function () {
       .replaceAll("/@", "/");
   };
 
-  const addPRsToDoc = (prs) => {
+  const addPRsToDoc = (prs, codex) => {
+    console.log("codex", codex);
     $("#ghHolder").append(
       "<button class='run-watermelon'>Run Watermelon</button><br/>"
     );
-    $("#ghHolder").append(
-      `<p'>${explanation}</p>`
-    );
+
     $("#ghHolder").append(
       `<button class='help-link'>Get help from ${authorName}</button>`
     );
@@ -62,6 +61,9 @@ $(document).ready(function () {
     $(".help-link").on("click", (event) => {
       sendMessage({ command: "open-link", link: "https://app.slack.com" });
     });
+    $("#ghHolder").append(
+      `<p>${codex}</p>`
+    );
     prs.forEach((pr, index) => {
       let mdComments = "";
       pr.comments.forEach((comment) => {
@@ -197,11 +199,12 @@ $(document).ready(function () {
   }
 
   window.addEventListener("message", (event) => {
+    console.log("messge received", event.data.codeExplanation);
     const message = event.data; // The JSON data our extension sent
     switch (message.command) {
       case "prs":
         removeLoading();
-        addPRsToDoc(message.data);
+        addPRsToDoc(message.data, event.data.codeExplanation);
         break;
       case "loading":
         setLoading();
@@ -212,9 +215,6 @@ $(document).ready(function () {
       case "author":
         authorName = message.author;
         break;
-      case "explanation":
-        console.log("message.explanation - main.js: ", message.explanation);
-        explanation = message.explanation;
     }
   });
 });

--- a/media/main.js
+++ b/media/main.js
@@ -47,7 +47,6 @@ $(document).ready(function () {
   };
 
   const addPRsToDoc = (prs, codex) => {
-    console.log("codex", codex);
     $("#ghHolder").append(
       "<button class='run-watermelon'>Run Watermelon</button><br/>"
     );
@@ -199,7 +198,6 @@ $(document).ready(function () {
   }
 
   window.addEventListener("message", (event) => {
-    console.log("messge received", event.data.explanation);
     const message = event.data; // The JSON data our extension sent
     switch (message.command) {
       case "prs":

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "menus": {
       "editor/context": [
         {
-        "command": "watermelon.start",
-        "when": "editorHasSelection"     
+          "command": "watermelon.start",
+          "when": "editorHasSelection"
         }
       ]
     }
@@ -107,6 +107,7 @@
     "@vscode/test-electron": "^2.1.2",
     "axios": "^0.26.1",
     "glob": "^7.2.0",
-    "mocha": "^9.2.2"
+    "mocha": "^9.2.2",
+    "openai": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@vscode/test-electron": "^2.1.2",
     "axios": "^0.26.1",
     "glob": "^7.2.0",
-    "mocha": "^9.2.2",
-    "openai": "^2.0.5"
+    "mocha": "^9.2.2"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,9 +235,7 @@ class watermelonSidebar implements vscode.WebviewViewProvider {
   }
   public sendMessage(message: any) {
     if (this._view) {
-      console.log("codeExplanation - sendMessage extension.ts: ", codeExplanation);
       message.explanation = codeExplanation;
-      console.log("extension.ts - publicSendMessage  - message: ", message);
       this._view.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
       this._view.webview.postMessage(message);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ class watermelonSidebar implements vscode.WebviewViewProvider {
   public static readonly viewType = "watermelon.sidebar";
 
   private _view?: vscode.WebviewView;
-  codeExplanation: any;
+  // codeExplanation: any;
 
   constructor(private readonly _extensionUri: vscode.Uri) {}
   public resolveWebviewView(
@@ -180,8 +180,10 @@ class watermelonSidebar implements vscode.WebviewViewProvider {
           });
 
           // Call Open AI's API to explain the code
-          this.codeExplanation = await explainCode({  
+          codeExplanation = await explainCode({  
             wrangledBlockOfCode: selectedBlockOfCode as string
+          }).then((res) => {
+            return res.data;
           });
 
           userEmail = await getUserEmail({ octokit });
@@ -233,8 +235,8 @@ class watermelonSidebar implements vscode.WebviewViewProvider {
   }
   public sendMessage(message: any) {
     if (this._view) {
-      console.log("this.codeExplanation: ", this.codeExplanation.data);
-      // message.explanation = this.codeExplanation.data;
+      console.log("codeExplanation - sendMessage extension.ts: ", codeExplanation);
+      message.explanation = codeExplanation;
       console.log("extension.ts - publicSendMessage  - message: ", message);
       this._view.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
       this._view.webview.postMessage(message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,6 @@ class watermelonSidebar implements vscode.WebviewViewProvider {
   public static readonly viewType = "watermelon.sidebar";
 
   private _view?: vscode.WebviewView;
-  // codeExplanation: any;
 
   constructor(private readonly _extensionUri: vscode.Uri) {}
   public resolveWebviewView(

--- a/src/utils/openai/explainCode.ts
+++ b/src/utils/openai/explainCode.ts
@@ -1,0 +1,18 @@
+import { backendURL } from "../../constants";
+
+const axios = require("axios");
+
+export default async function explainCode({
+  wrangledBlockOfCode
+}: {
+  wrangledBlockOfCode: string;
+}) {
+  let resp = await axios.post(
+    // `${backendURL}/api/analytics/github/search`,
+    `http://localhost:3001/api/gpt3/explainCode`,
+    {
+      codeBlock: wrangledBlockOfCode
+    }
+  );
+  return resp;
+}

--- a/src/utils/openai/explainCode.ts
+++ b/src/utils/openai/explainCode.ts
@@ -8,8 +8,7 @@ export default async function explainCode({
   wrangledBlockOfCode: string;
 }) {
   let resp = await axios.post(
-    // `${backendURL}/api/analytics/github/search`,
-    `http://localhost:3001/api/gpt3/explainCode`,
+    `${backendURL}/api/gpt3/explainCode`,
     {
       codeBlock: wrangledBlockOfCode
     }


### PR DESCRIPTION
## Description
When Run Watermelon is clicked, we also provide the code explanation in plain english on top the PR Body. It's language agnostic but it works best with the mainstream languages. 

<img width="459" alt="Screen Shot 2022-05-04 at 11 45 15 AM" src="https://user-images.githubusercontent.com/8325094/166736545-f9c1e161-f696-4d86-abd5-5450f6e30199.png">


## Type of change
- New feature (non-breaking change which adds functionality)