### PR TITLE
Remove codex from html

### DIFF
--- a/media/utils/addPRsToDoc.js
+++ b/media/utils/addPRsToDoc.js
@@ -19,9 +19,6 @@ const addPRsToDoc = (prs, codex) => {
     sendMessage({ command: "create-docs" });
   });
   $("#ghHolder").append(`
-  <h3>Code Explanation</h3>
-  <p>${codex}</p>`);
-  $("#ghHolder").append(`
   <h3>Pull Requests</h3>
   `);
   prs.forEach((pr, index) => {


### PR DESCRIPTION
## Description
The Code Explanation <h3> tag has been removed. 

## Type of change

Please delete options that are not relevant or write your own.
- Chore: cleanup/renaming, etc
