### PR TITLE
fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ Watermelon is built by a globally distributed team of developers devoted to maki
 
 ### License
 
-- [Apache License](https://github.com/watermelontools/wm-extension/blob/main/LICENSE)
+- [Apache License](https://github.com/watermelontools/wm-extension/blob/dev/license.md)
 


### PR DESCRIPTION
## Description
As noted in this issue https://github.com/watermelontools/wm-extension/issues/227 the license link is broken. This PR fixes it. 

## Type of change
- Chore: cleanup/renaming, etc
