### PR TITLE
Added line counter on status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [1.2.2]
 - New Telemetry
+- Activate from the counter on the bottom bar 
 ## [1.2.1]
 - Fixes to DX
 ## [1.2.0]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,22 +50,29 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
   let myStatusBarItem: vscode.StatusBarItem;
-  	// create a new status bar item that we can now manage
-	myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
-	myStatusBarItem.command = "watermelon.start";
-	context.subscriptions.push(myStatusBarItem);
+  // create a new status bar item that we can now manage
+  myStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100
+  );
+  myStatusBarItem.command = "watermelon.start";
+  context.subscriptions.push(myStatusBarItem);
 
-	// register some listener that make sure the status bar 
-	// item always up-to-date
-	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async () => {
-    updateStatusBarItem(myStatusBarItem);
-    }));
-	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(async () => {
-    updateStatusBarItem(myStatusBarItem);
-    }));
-	// update status bar item once at start
-	updateStatusBarItem(myStatusBarItem);
-  
+  // register some listener that make sure the status bar
+  // item always up-to-date
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(async () => {
+      updateStatusBarItem(myStatusBarItem);
+    })
+  );
+  context.subscriptions.push(
+    vscode.window.onDidChangeTextEditorSelection(async () => {
+      updateStatusBarItem(myStatusBarItem);
+    })
+  );
+  // update status bar item once at start
+  updateStatusBarItem(myStatusBarItem);
+
   let { repoName, ownerUsername } = await getRepoInfo();
   repo = repoName;
   owner = ownerUsername;
@@ -123,11 +130,13 @@ export async function activate(context: vscode.ExtensionContext) {
     let selectedCode = "";
     if (selection.selections.length > 0) {
       let selectedText = selection;
-      selectedCode= selectedText.textEditor.document.getText(selectedText.selections[0]);
+      selectedCode = selectedText.textEditor.document.getText(
+        selectedText.selections[0]
+      );
     }
     // Replace newlines with \n
-    selectedBlockOfCode = selectedCode.replace(/(\r\n|\n|\r)/gm,"");
-    
+    selectedBlockOfCode = selectedCode.replace(/(\r\n|\n|\r)/gm, "");
+
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,
@@ -149,4 +158,3 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   }
 }
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,8 +64,8 @@ export async function activate(context: vscode.ExtensionContext) {
   function updateStatusBarItem(): void {
     const n = getNumberOfSelectedLines(vscode.window.activeTextEditor);
     if (n > 0) {
-      myStatusBarItem.text = `$(eye) ${n} line(s) selected`;
-      myStatusBarItem.tooltip= "Click to open Watermelon";
+      myStatusBarItem.text = `Run Watermelon with the ${n} line(s) selected`;
+      myStatusBarItem.tooltip= "Click here to run Watermelon";
       myStatusBarItem.show();
     } else {
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import getUserEmail from "./utils/getUserEmail";
 import searchType from "./utils/analytics/searchType";
 import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
 import watermelonSidebar from "./watermelonSidebar";
+import updateStatusBarItem from "./utils/vscode/updateStatusBarItem";
 
 // repo information
 let owner: string | undefined = "";
@@ -56,29 +57,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// register some listener that make sure the status bar 
 	// item always up-to-date
-	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(updateStatusBarItem));
-	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateStatusBarItem));
-
+	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async () => {
+    updateStatusBarItem(myStatusBarItem);
+    }));
+	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(async () => {
+    updateStatusBarItem(myStatusBarItem);
+    }));
 	// update status bar item once at start
-	updateStatusBarItem();
-  function updateStatusBarItem(): void {
-    const n = getNumberOfSelectedLines(vscode.window.activeTextEditor);
-    if (n > 0) {
-      myStatusBarItem.text = `Run Watermelon with the ${n} line(s) selected`;
-      myStatusBarItem.tooltip= "Click here to run Watermelon";
-      myStatusBarItem.show();
-    } else {
-
-      myStatusBarItem.tooltip= "Watermelon: Select lines to view context";
-    }
-  }
-  function getNumberOfSelectedLines(editor: vscode.TextEditor | undefined): number {
-    let lines = 0;
-    if (editor) {
-      lines = editor.selections.reduce((prev, curr) => prev + (curr.end.line - curr.start.line), 0);
-    }
-    return lines;
-  }
+	updateStatusBarItem(myStatusBarItem);
+  
   let { repoName, ownerUsername } = await getRepoInfo();
   repo = repoName;
   owner = ownerUsername;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import getBlame from "./utils/getBlame";
 import searchType from "./utils/analytics/searchType";
 import getPackageInfo from "./utils/getPackageInfo";
 import TelemetryReporter from "@vscode/extension-telemetry";
+import updateStatusBarItem from "./utils/vscode/updateStatusBarItem";
 
 // repo information
 let owner: string | undefined = "";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,37 @@ export async function activate(context: vscode.ExtensionContext) {
       provider
     )
   );
+  let myStatusBarItem: vscode.StatusBarItem;
+  	// create a new status bar item that we can now manage
+	myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+	myStatusBarItem.command = "watermelon.start";
+	context.subscriptions.push(myStatusBarItem);
+
+	// register some listener that make sure the status bar 
+	// item always up-to-date
+	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(updateStatusBarItem));
+	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateStatusBarItem));
+
+	// update status bar item once at start
+	updateStatusBarItem();
+  function updateStatusBarItem(): void {
+    const n = getNumberOfSelectedLines(vscode.window.activeTextEditor);
+    if (n > 0) {
+      myStatusBarItem.text = `$(eye) ${n} line(s) selected`;
+      myStatusBarItem.tooltip= "Click to open Watermelon";
+      myStatusBarItem.show();
+    } else {
+
+      myStatusBarItem.tooltip= "Watermelon: Select lines to view context";
+    }
+  }
+  function getNumberOfSelectedLines(editor: vscode.TextEditor | undefined): number {
+    let lines = 0;
+    if (editor) {
+      lines = editor.selections.reduce((prev, curr) => prev + (curr.end.line - curr.start.line), 0);
+    }
+    return lines;
+  }
   let { repoName, ownerUsername } = await getRepoInfo();
   repo = repoName;
   owner = ownerUsername;

--- a/src/utils/vscode/updateStatusBarItem.ts
+++ b/src/utils/vscode/updateStatusBarItem.ts
@@ -1,0 +1,21 @@
+import * as vscode from "vscode";
+
+function getNumberOfSelectedLines(editor: vscode.TextEditor | undefined): number {
+    let lines = 0;
+    if (editor) {
+      lines = editor.selections.reduce((prev, curr) => prev + (curr.end.line - curr.start.line), 0);
+    }
+    return lines;
+  }
+function updateStatusBarItem(myStatusBarItem:vscode.StatusBarItem): void {
+    const n = getNumberOfSelectedLines(vscode.window.activeTextEditor);
+    if (n > 0) {
+      myStatusBarItem.text = `Run Watermelon with the ${n} line(s) selected`;
+      myStatusBarItem.tooltip= "Click here to run Watermelon";
+      myStatusBarItem.show();
+    } else {
+
+      myStatusBarItem.tooltip= "Watermelon: Select lines to view context";
+    }
+  }
+  export default updateStatusBarItem;


### PR DESCRIPTION
## Description
Added status bar line counter as an experiment. Will run the `watermelon.start` command on click
## Type of change

- New feature (non-breaking change which adds functionality)

<img width="264" alt="Screen Shot 2022-05-15 at 7 46 40 PM" src="https://user-images.githubusercontent.com/11527621/168502300-b5c4464b-2931-49f8-b398-e4f0b0d4f855.png">

- Chore: cleanup/renaming, etc
