### PR TITLE
Add vsc telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+
+## [1.2.2]
+- New Telemetry
+## [1.2.1]
+- Fixes to DX
 ## [1.2.0]
 - Allow private repo access (requires logging in again)
 - Added scope to allow private repos

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "dependencies": {
     "@octokit/core": "^3.5.1",
     "@octokit/rest": "^18.12.0",
+    "@vscode/extension-telemetry": "^0.5.1",
     "@vscode/test-electron": "^2.1.2",
     "axios": "^0.26.1",
     "glob": "^7.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const credentials = new Credentials();
   await credentials.initialize(context);
 
-  const provider = new WatermelonSidebar(context);
+  const provider = new WatermelonSidebar(context, reporter);
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as Path from "path";
 import * as fs from "fs";
-
+import TelemetryReporter from '@vscode/extension-telemetry';
 import { Credentials } from "./credentials";
 import getWebviewOptions from "./utils/vscode/getWebViewOptions";
 import getGitAPI from "./utils/vscode/getGitAPI";
@@ -13,6 +13,18 @@ import getUserEmail from "./utils/getUserEmail";
 import searchType from "./utils/analytics/searchType";
 import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
 import watermelonSidebar from "./watermelonSidebar";
+
+// all events will be prefixed with this event name
+const extensionId = 'WatermelonTools.watermelon-tools';
+
+// extension version will be reported as a property with each event
+const extensionVersion = '1.1.5';
+
+// the application insights key (also known as instrumentation key)
+const key = process.env.AZURE_APPINSIGHTS_INSTRUMENTATIONKEY;
+
+// telemetry reporter
+let reporter: any;
 
 // repo information
 let owner: string | undefined = "";
@@ -27,6 +39,11 @@ let arrayOfSHAs: string[] = [];
 let octokit: any;
 
 export async function activate(context: vscode.ExtensionContext) {
+   // create telemetry reporter on extension activation
+   reporter = new TelemetryReporter(extensionId, extensionVersion, key);
+   // ensure it gets properly disposed. Upon disposal the events will be flushed
+   context.subscriptions.push(reporter);
+
   setLoggedIn(false);
   var extensionPath = Path.join(context.extensionPath, "package.json");
   var packageFile = JSON.parse(fs.readFileSync(extensionPath, "utf8"));
@@ -99,6 +116,8 @@ export async function activate(context: vscode.ExtensionContext) {
   octokit = await credentials.getOctokit();
 
   vscode.window.onDidChangeTextEditorSelection(async (selection) => {    
+    // Testing for draft PR
+    reporter.sendTelemetryEvent('sampleEvent', { 'stringProp': 'some string' }, { 'numericMeasure': 123 });
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,3 +146,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
+export async function deactivate() {
+  // This will ensure all pending events get flushed
+   reporter.dispose();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,9 @@ import setLoggedIn from "./utils/vscode/setLoggedIn";
 import getLocalUser from "./utils/vscode/getLocalUser";
 import getRepoInfo from "./utils/vscode/getRepoInfo";
 import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
-import watermelonSidebar from "./watermelonSidebar";
+import WatermelonSidebar from "./watermelonSidebar";
 import getBlame from "./utils/getBlame";
+import searchType from "./utils/analytics/searchType";
 
 // repo information
 let owner: string | undefined = "";
@@ -36,11 +37,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const credentials = new Credentials();
   await credentials.initialize(context);
 
-  const provider = new watermelonSidebar(context);
+  const provider = new WatermelonSidebar(context);
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
-      watermelonSidebar.viewType,
+      WatermelonSidebar.viewType,
       provider
     )
   );
@@ -89,7 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
       });
       localUser = await getLocalUser();
       octokit = await credentials.getOctokit();
-      let uniqueBlames = await getBlame(gitAPI)
+      let uniqueBlames = await getBlame(gitAPI);
       provider.sendMessage({
         command: "blame",
         data: uniqueBlames,
@@ -120,7 +121,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (vscode.window.registerWebviewPanelSerializer) {
     // Make sure we register a serializer in activation event
-    vscode.window.registerWebviewPanelSerializer(watermelonSidebar.viewType, {
+    vscode.window.registerWebviewPanelSerializer(WatermelonSidebar.viewType, {
       async deserializeWebviewPanel(
         webviewPanel: vscode.WebviewPanel,
         state: any

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
 import WatermelonSidebar from "./watermelonSidebar";
 import getBlame from "./utils/getBlame";
 import searchType from "./utils/analytics/searchType";
+import getPackageInfo from "./utils/getPackageInfo";
+import TelemetryReporter from "@vscode/extension-telemetry";
 
 // repo information
 let owner: string | undefined = "";
@@ -25,14 +27,25 @@ let arrayOfSHAs: string[] = [];
 
 let octokit: any;
 
+// all events will be prefixed with this event name
+const extensionId = 'WatermelonTools.watermelon-tools';
+
+// extension version will be reported as a property with each event
+const extensionVersion = getPackageInfo().version;
+
+// the application insights key (also known as instrumentation key)
+const key = '4ed9e755-be2b-460b-9309-426fb5f58c6f';
+
+// telemetry reporter
+let reporter: any;
+
 export async function activate(context: vscode.ExtensionContext) {
   setLoggedIn(false);
-  var extensionPath = Path.join(context.extensionPath, "package.json");
-  var packageFile = JSON.parse(fs.readFileSync(extensionPath, "utf8"));
 
-  if (packageFile) {
-    console.log(packageFile.version);
-  }
+  // create telemetry reporter on extension activation
+  reporter = new TelemetryReporter(extensionId, extensionVersion, key);
+  // ensure it gets properly disposed. Upon disposal the events will be flushed
+  context.subscriptions.push(reporter);
   let gitAPI = await getGitAPI();
   const credentials = new Credentials();
   await credentials.initialize(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import * as Path from "path";
 import * as fs from "fs";
-import TelemetryReporter from '@vscode/extension-telemetry';
 import { Credentials } from "./credentials";
 import getWebviewOptions from "./utils/vscode/getWebViewOptions";
 import getGitAPI from "./utils/vscode/getGitAPI";
@@ -9,22 +8,8 @@ import getSHAArray from "./utils/getSHAArray";
 import setLoggedIn from "./utils/vscode/setLoggedIn";
 import getLocalUser from "./utils/vscode/getLocalUser";
 import getRepoInfo from "./utils/vscode/getRepoInfo";
-import getUserEmail from "./utils/getUserEmail";
-import searchType from "./utils/analytics/searchType";
 import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
 import watermelonSidebar from "./watermelonSidebar";
-
-// all events will be prefixed with this event name
-const extensionId = 'WatermelonTools.watermelon-tools';
-
-// extension version will be reported as a property with each event
-const extensionVersion = '1.1.5';
-
-// the application insights key (also known as instrumentation key)
-const key = process.env.AZURE_APPINSIGHTS_INSTRUMENTATIONKEY;
-
-// telemetry reporter
-let reporter: any;
 
 // repo information
 let owner: string | undefined = "";
@@ -39,11 +24,6 @@ let arrayOfSHAs: string[] = [];
 let octokit: any;
 
 export async function activate(context: vscode.ExtensionContext) {
-   // create telemetry reporter on extension activation
-   reporter = new TelemetryReporter(extensionId, extensionVersion, key);
-   // ensure it gets properly disposed. Upon disposal the events will be flushed
-   context.subscriptions.push(reporter);
-
   setLoggedIn(false);
   var extensionPath = Path.join(context.extensionPath, "package.json");
   var packageFile = JSON.parse(fs.readFileSync(extensionPath, "utf8"));
@@ -99,14 +79,6 @@ export async function activate(context: vscode.ExtensionContext) {
         command: "prs",
         data: issuesWithTitlesAndGroupedComments,
       });
-      userEmail = await getUserEmail({ octokit });
-      searchType({
-        searchType: "watermelon.start",
-        owner,
-        repo,
-        localUser,
-        userEmail,
-      });
     })
   );
 
@@ -116,8 +88,6 @@ export async function activate(context: vscode.ExtensionContext) {
   octokit = await credentials.getOctokit();
 
   vscode.window.onDidChangeTextEditorSelection(async (selection) => {    
-    // Testing for draft PR
-    reporter.sendTelemetryEvent('sampleEvent', { 'stringProp': 'some string' }, { 'numericMeasure': 123 });
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/utils/getPackageInfo.ts
+++ b/src/utils/getPackageInfo.ts
@@ -1,0 +1,9 @@
+function getPackageInfo() {
+    const packageJson = require('../../package.json');
+    return {
+        name: packageJson.name,
+        version: packageJson.version,
+        description: packageJson.description,
+    };
+}
+export default getPackageInfo;

--- a/src/watermelonSidebar.ts
+++ b/src/watermelonSidebar.ts
@@ -2,36 +2,15 @@ import createDocs from "./utils/analytics/createDocs";
 import getNonce from "./utils/vscode/getNonce";
 import getInitialHTML from "./utils/vscode/getInitialHTML";
 import * as vscode from "vscode";
-import TelemetryReporter from '@vscode/extension-telemetry';
 import getGitAPI from "./utils/vscode/getGitAPI";
 import getUserEmail from "./utils/getUserEmail";
 import getLocalUser from "./utils/vscode/getLocalUser";
 import getSHAArray from "./utils/getSHAArray";
 import { Credentials } from "./credentials";
 import getPRsToPaintPerSHAs from "./utils/vscode/getPRsToPaintPerSHAs";
-import getFullBlame from "./utils/getFullBlame";
-import searchType from "./utils/analytics/searchType";
 import getRepoInfo from "./utils/vscode/getRepoInfo";
 import getBlame from "./utils/getBlame";
 
-// all events will be prefixed with this event name
-const extensionId = 'WatermelonTools.watermelon-tools';
-
-// extension version will be reported as a property with each event
-const extensionVersion = '1.1.5';
-
-// the application insights key (also known as instrumentation key)
-const key = '4ed9e755-be2b-460b-9309-426fb5f58c6f';
-
-// telemetry reporter
-let reporter: any;
-
-function activate(context: vscode.ExtensionContext) {
-  // create telemetry reporter on extension activation
-  reporter = new TelemetryReporter(extensionId, extensionVersion, key);
-  // ensure it gets properly disposed. Upon disposal the events will be flushed
-  context.subscriptions.push(reporter);
-}
 
 // repo information
 let owner: string | undefined = "";

--- a/src/watermelonSidebar.ts
+++ b/src/watermelonSidebar.ts
@@ -44,7 +44,7 @@ let arrayOfSHAs: string[] = [];
 
 let octokit: any;
 
-export default class watermelonSidebar implements vscode.WebviewViewProvider {
+export default class WatermelonSidebar implements vscode.WebviewViewProvider {
   public static readonly viewType = "watermelon.sidebar";
   public _extensionUri: vscode.Uri;
   private _view?: vscode.WebviewView;
@@ -174,7 +174,7 @@ export default class watermelonSidebar implements vscode.WebviewViewProvider {
           this.sendMessage({
             command: "loading",
           });
-          let uniqueBlames = await getBlame(gitAPI)
+          let uniqueBlames = await getBlame(gitAPI);
           this.sendMessage({
             command: "blame",
             data: uniqueBlames,

--- a/src/watermelonSidebar.ts
+++ b/src/watermelonSidebar.ts
@@ -31,6 +31,7 @@ export default class WatermelonSidebar implements vscode.WebviewViewProvider {
   constructor(private readonly context: vscode.ExtensionContext, public reporter: any) {
     this._extensionUri = context.extensionUri;
     this._context = context;
+    this.reporter = reporter;
   }
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
@@ -90,7 +91,7 @@ export default class WatermelonSidebar implements vscode.WebviewViewProvider {
           );
           
           // Send Event to VSC Telemtry Library
-          reporter.sendTelemetryEvent('pullRequests');
+          this.reporter.sendTelemetryEvent('pullRequests');
 
           this.sendMessage({
             command: "prs",
@@ -100,7 +101,7 @@ export default class WatermelonSidebar implements vscode.WebviewViewProvider {
         }
         case "create-docs": {
           // Send Event to VSC Telemtry Library
-          reporter.sendTelemetryEvent('createDocs');
+          this.reporter.sendTelemetryEvent('createDocs');
 
           const wsedit = new vscode.WorkspaceEdit();
           if (vscode.workspace.workspaceFolders) {
@@ -148,7 +149,7 @@ export default class WatermelonSidebar implements vscode.WebviewViewProvider {
         }
         case "blame": {
         // Send Event to VSC Telemtry Library
-        reporter.sendTelemetryEvent('viewBlame');
+        this.reporter.sendTelemetryEvent('viewBlame');
 
           this.sendMessage({
             command: "loading",

--- a/src/watermelonSidebar.ts
+++ b/src/watermelonSidebar.ts
@@ -28,7 +28,7 @@ export default class WatermelonSidebar implements vscode.WebviewViewProvider {
   public _extensionUri: vscode.Uri;
   private _view?: vscode.WebviewView;
   private _context: vscode.ExtensionContext;
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(private readonly context: vscode.ExtensionContext, public reporter: any) {
     this._extensionUri = context.extensionUri;
     this._context = context;
   }

--- a/src/watermelonSidebar.ts
+++ b/src/watermelonSidebar.ts
@@ -21,7 +21,7 @@ const extensionId = 'WatermelonTools.watermelon-tools';
 const extensionVersion = '1.1.5';
 
 // the application insights key (also known as instrumentation key)
-const key = process.env.AZURE_APPINSIGHTS_INSTRUMENTATIONKEY as string;
+const key = '4ed9e755-be2b-460b-9309-426fb5f58c6f';
 
 // telemetry reporter
 let reporter: any;


### PR DESCRIPTION
## Description
As we learned during our Show HN launch, we should be using VS Code's Telemetry service. This is a draft PR that tests sending an event to the newly opened App Insights resource when a user changes its code selection. 

## Type of change
Please delete options that are not relevant or write your own.
- New feature (non-breaking change which adds functionality)
