### PR TITLE
Feature/rename git blame to vierw commit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,9 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.2.4]
-
-- "Git blame" now referred to as "Commit History" for clarity
-
 ## [1.2.3]
 
+- "Git blame" now referred to as "Commit History" for clarity
 - Now you can click on the commit id to view on github on the blame table
 - Added right click to get blame
 - Changed "Start Watermelon" command with "Get Pull Requests with Watermelon"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.4]
+
+- "Git blame" now referred to as "Commit History" for clarity
+
 ## [1.2.3]
 
 - Now you can click on the commit id to view on github on the blame table

--- a/media/utils/addActionButtons.js
+++ b/media/utils/addActionButtons.js
@@ -9,7 +9,7 @@ const addActionButtons = () => {
   );
   $("#ghHolder").append(
     `<p>We will fetch the associated PRs and comments for you to understand the context of the code</p>
-        <button class='git-blame'>View Git Blame</button>
+        <button class='git-blame'>View Commit History</button>
         <br/>`
   );
   $("#ghHolder").append(

--- a/media/utils/addActionButtons.js
+++ b/media/utils/addActionButtons.js
@@ -8,7 +8,7 @@ const addActionButtons = () => {
         <br/>`
   );
   $("#ghHolder").append(
-    `<p>We will fetch the associated PRs and comments for you to understand the context of the code</p>
+    `<p>We will fetch the commit history for you to understand the context of the code</p>
         <button class='git-blame'>View Commit History</button>
         <br/>`
   );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       },
       {
         "command": "watermelon.blame",
-        "title": "Get watermelon blame",
+        "title": "Get Commit History with Watermelon",
         "category": "watermelon"
       }
     ],

--- a/src/utils/vscode/getInitialHTML.ts
+++ b/src/utils/vscode/getInitialHTML.ts
@@ -22,7 +22,7 @@ export default function getInitialHTML(
     "https://*.github.io",
     "https://cdn.webflow.com/",
     "https://codecov.io/",
-    "https://i.imgur.com"
+    "https://i.imgur.com",
   ];
   let scriptSources = [
     `'nonce-${nonce}'`,
@@ -87,8 +87,8 @@ export default function getInitialHTML(
            <p>Higlight a piece of code to start.</p>
            <p>We can help you document your code:</p>
            <button class='create-docs'>Create Repo docs</button>
-           <p>We will fetch the associated PRs and comments for you to understand the context of the code</p>
-           <button class='git-blame'>View Git Blame</button>
+           <p>We will fetch the commit history for you to understand the context of the code</p>
+           <button class='git-blame'>View Commit History</button>
            <p>Click this button to enrich your code with relevant information from GitHub:</p>
            <button class='run-watermelon'>View Pull Requests (Beta)</button>
            <p>Alternatively, you can <a href="https://github.com/watermelontools/wm-extension#commands">run with our watermelon.start command</a></p>


### PR DESCRIPTION
## Description
Git blame now callled "view commit history" for clarity
## Type of change

- New feature (non-breaking change which adds functionality)

- Chore: cleanup/renaming, etc
