### PR TITLE
Add case for SSH cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added right click to get blame
 - Changed "Start Watermelon" command with "Get Pull Requests with Watermelon"
 - Instructions will now show up in every screen
+- Now works on SSH cloned repos
 
 ## [1.2.2]
 

--- a/src/utils/vscode/getRepoInfo.ts
+++ b/src/utils/vscode/getRepoInfo.ts
@@ -8,14 +8,15 @@ export default async function getRepoInfo(): Promise<{
   let ownerUsername: string = "";
   let repoName: string = "";
 
-  let config = await (
-    await gitAPI?.repositories[0]?.getConfig("remote.origin.url")
-  )?.split("/");
-  if (config) {
-    repoName = config[4].split(".")[0];
-    ownerUsername = config[3];
-    return { ownerUsername, repoName };
+  let config = await await gitAPI?.repositories[0]?.getConfig(
+    "remote.origin.url"
+  );
+  if (config?.includes("https://")) {
+    repoName = config?.split("/")[4].split(".")[0];
+    ownerUsername = config?.split("/")[3];
   } else {
-    return { ownerUsername: "watermelon", repoName: "watermelon" };
+    repoName = config?.split("/")[1].split(".")[0] ?? "";
+    ownerUsername = config?.split(":")[1].split("/")[0] ?? "";
   }
+  return { ownerUsername, repoName };
 }


### PR DESCRIPTION
## Description
Now works on SSH
SSH:
```
[remote "origin"]
        url = git@github.com:platanus/ventures-nest.git
        fetch = +refs/heads/*:refs/remotes/origin/*
```
HTTPS:
```
[remote "origin"]
	url = https://github.com/watermelontools/wm-extension.git
	fetch = +refs/heads/*:refs/remotes/origin/*
	gh-resolved = base
```
## Type of change

- Bug fix (non-breaking change which fixes an issue)

