### PR TITLE
Feature/getNumberOfLineChanges

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,7 +151,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   octokit = await credentials.getOctokit();
 
-  vscode.window.onDidChangeTextEditorSelection(async (selection) => {    
+  vscode.window.onDidChangeTextEditorSelection(async (selection) => {
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,6 @@ import searchType from "./utils/analytics/searchType";
 import getPackageInfo from "./utils/getPackageInfo";
 import TelemetryReporter from "@vscode/extension-telemetry";
 import updateStatusBarItem from "./utils/vscode/updateStatusBarItem";
-import getFileChurn from "./utils/getFileChurn";
 
 // repo information
 let owner: string | undefined = "";
@@ -152,10 +151,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   octokit = await credentials.getOctokit();
 
-  vscode.window.onDidChangeTextEditorSelection(async (selection) => {
-    let churnResult = getFileChurn(selection.textEditor.document.uri.fsPath);
-    console.log("churn result: ", churnResult);
-    
+  vscode.window.onDidChangeTextEditorSelection(async (selection) => {    
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import searchType from "./utils/analytics/searchType";
 import getPackageInfo from "./utils/getPackageInfo";
 import TelemetryReporter from "@vscode/extension-telemetry";
 import updateStatusBarItem from "./utils/vscode/updateStatusBarItem";
+import getFileChurn from "./utils/getFileChurn";
 
 // repo information
 let owner: string | undefined = "";
@@ -152,6 +153,9 @@ export async function activate(context: vscode.ExtensionContext) {
   octokit = await credentials.getOctokit();
 
   vscode.window.onDidChangeTextEditorSelection(async (selection) => {
+    let churnResult = getFileChurn(selection.textEditor.document.uri.fsPath);
+    console.log("churn result: ", churnResult);
+    
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/utils/getNumberOfLineChanges.ts
+++ b/src/utils/getNumberOfLineChanges.ts
@@ -1,12 +1,10 @@
 import * as vscode from "vscode";
 import getFullBlame from "./getFullBlame";
 
-async function getNumberOfLineChanges(gitAPI:any) {
+async function getNumberOfLineChanges(gitAPI:any, lineNumber:number) {
     let blamePromises = await getFullBlame(
-        vscode?.window?.activeTextEditor?.selection.start.line ?? 1,
-        vscode?.window?.activeTextEditor?.selection.end.line ??
-        vscode.window.activeTextEditor?.document.lineCount ??
-        2,
+        lineNumber,
+        lineNumber,
         vscode.window.activeTextEditor?.document.uri.fsPath,
         gitAPI
     );
@@ -20,15 +18,7 @@ async function getNumberOfLineChanges(gitAPI:any) {
             }
         });
 
-        const uniqueBlames = [
-            ...new Map(
-                blames.map((item) =>
-                    // @ts-ignore
-                    [item["message"], item]
-                )
-            ).values(),
-        ];
-        return uniqueBlames.length;
+        return blames.length;
     });
 }
 export default getNumberOfLineChanges;

--- a/src/utils/getNumberOfLineChanges.ts
+++ b/src/utils/getNumberOfLineChanges.ts
@@ -1,0 +1,34 @@
+import * as vscode from "vscode";
+import getFullBlame from "./getFullBlame";
+
+async function getNumberOfLineChanges(gitAPI:any) {
+    let blamePromises = await getFullBlame(
+        vscode?.window?.activeTextEditor?.selection.start.line ?? 1,
+        vscode?.window?.activeTextEditor?.selection.end.line ??
+        vscode.window.activeTextEditor?.document.lineCount ??
+        2,
+        vscode.window.activeTextEditor?.document.uri.fsPath,
+        gitAPI
+    );
+    return Promise.allSettled(blamePromises).then((results) => {
+        let blames: string[] = [];
+        results.forEach((result) => {
+            if (result.status === "fulfilled") {
+                blames.push(result.value);
+            } else {
+                blames.push(result.reason);
+            }
+        });
+
+        const uniqueBlames = [
+            ...new Map(
+                blames.map((item) =>
+                    // @ts-ignore
+                    [item["message"], item]
+                )
+            ).values(),
+        ];
+        return uniqueBlames.length;
+    });
+}
+export default getNumberOfLineChanges;


### PR DESCRIPTION
## Description
Get the number of line changes for a line or a range of lines. It runs the blame we already know, and then gets the length of the commit hash array. This is a prerequisite for the context box we're about to release. 

## Type of change
Please delete options that are not relevant or write your own.
- New feature (non-breaking change which adds functionality)
