### PR TITLE
Fix/see more button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.4]
+
+- Now the "see more" button for code blocks sits _outside_ the code block.
+
 ## [1.2.3]
 
 - Promoted "View PRs" from Beta to stable.

--- a/media/utils/clampCodeBlocks.js
+++ b/media/utils/clampCodeBlocks.js
@@ -3,11 +3,11 @@ function clampCodeBlocks() {
     // replace each with the clamped version and a see more button
     if ($(this).text().length > 100) {
       $(this).addClass("clamp");
-      $(this).append("<button class='see-more'>See More</button>");
+      $(this).after("<button class='see-more'>See More</button>");
     }
     // now restore the text when the button was clicked
-    $(this).on("click", ".see-more", function () {
-      $(this).parent().removeClass("clamp");
+    $(".see-more").on("click", function () {
+      $(this).prev().removeClass("clamp");
       $(this).remove();
     });
   });

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -115,6 +115,17 @@ button {
   max-height: 3.5em;
   text-overflow: ellipsis;
 }
+.see-more{
+  cursor: pointer;
+  margin-top: -5px;
+  z-index: 2;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.see-more:hover {
+  margin-bottom: auto;
+}
 
 button:hover {
   background-color: #157241;


### PR DESCRIPTION
## Description
Now the see more button sits at the border of the code block, instead of inside
## Type of change
- Bug fix (non-breaking change which fixes an issue)
*BEFORE*

https://user-images.githubusercontent.com/11527621/170095775-80b69474-c65c-40c4-88af-26c875585e4b.mov


*AFTER*
https://user-images.githubusercontent.com/11527621/170095323-2b4aec96-7b3a-4070-9a5f-ec626b651503.mov
