### PR TITLE
Feature/ improve status bar message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,23 +59,23 @@ export async function activate(context: vscode.ExtensionContext) {
       provider
     )
   );
-  let myStatusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(
+  let wmStatusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     100
   );
-  myStatusBarItem.command = "watermelon.start";
-  context.subscriptions.push(myStatusBarItem);
+  wmStatusBarItem.command = "watermelon.start";
+  context.subscriptions.push(wmStatusBarItem);
 
   // register some listener that make sure the status bar
   // item always up-to-date
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async () => {
-      updateStatusBarItem(myStatusBarItem);
+      updateStatusBarItem(wmStatusBarItem);
     })
   );
 
   // update status bar item once at start
-  updateStatusBarItem(myStatusBarItem);
+  updateStatusBarItem(wmStatusBarItem);
 
   let { repoName, ownerUsername } = await getRepoInfo();
   repo = repoName;
@@ -143,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
   octokit = await credentials.getOctokit();
 
   vscode.window.onDidChangeTextEditorSelection(async (selection) => {
-    updateStatusBarItem(myStatusBarItem);
+    updateStatusBarItem(wmStatusBarItem);
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,11 +75,7 @@ export async function activate(context: vscode.ExtensionContext) {
       updateStatusBarItem(myStatusBarItem);
     })
   );
-  context.subscriptions.push(
-    vscode.window.onDidChangeTextEditorSelection(async () => {
-      updateStatusBarItem(myStatusBarItem);
-    })
-  );
+
   // update status bar item once at start
   updateStatusBarItem(myStatusBarItem);
 
@@ -149,6 +145,7 @@ export async function activate(context: vscode.ExtensionContext) {
   octokit = await credentials.getOctokit();
 
   vscode.window.onDidChangeTextEditorSelection(async (selection) => {
+    updateStatusBarItem(myStatusBarItem);
     arrayOfSHAs = await getSHAArray(
       selection.selections[0].start.line,
       selection.selections[0].end.line,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,9 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
       provider
     )
   );
-  let myStatusBarItem: vscode.StatusBarItem;
-  // create a new status bar item that we can now manage
-  myStatusBarItem = vscode.window.createStatusBarItem(
+  let myStatusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     100
   );

--- a/src/utils/vscode/updateStatusBarItem.ts
+++ b/src/utils/vscode/updateStatusBarItem.ts
@@ -10,7 +10,7 @@ function getNumberOfSelectedLines(editor: vscode.TextEditor | undefined): number
 function updateStatusBarItem(myStatusBarItem:vscode.StatusBarItem): void {
     const n = getNumberOfSelectedLines(vscode.window.activeTextEditor);
     if (n > 0) {
-      myStatusBarItem.text = `Run Watermelon with the ${n} line(s) selected`;
+      myStatusBarItem.text = `Run Watermelon with the ${n} line${n>1? "s": ""} selected`;
       myStatusBarItem.tooltip= "Click here to run Watermelon";
       myStatusBarItem.command = "watermelon.start";
     } else {

--- a/src/utils/vscode/updateStatusBarItem.ts
+++ b/src/utils/vscode/updateStatusBarItem.ts
@@ -12,10 +12,12 @@ function updateStatusBarItem(myStatusBarItem:vscode.StatusBarItem): void {
     if (n > 0) {
       myStatusBarItem.text = `Run Watermelon with the ${n} line(s) selected`;
       myStatusBarItem.tooltip= "Click here to run Watermelon";
-      myStatusBarItem.show();
+      myStatusBarItem.command = "watermelon.start";
     } else {
-
+      myStatusBarItem.text = `Open Watermelon to see code context`;
       myStatusBarItem.tooltip= "Watermelon: Select lines to view context";
+      myStatusBarItem.command = "watermelon.show";
     }
+    myStatusBarItem.show();
   }
   export default updateStatusBarItem;


### PR DESCRIPTION
## Description
To show value on startup, there is now a default text that shows up on start
Also, now it wont say "14 line(s)" and "1 line(s)", it will show "14 lines" and "1 line".
## Type of change

- New feature (non-breaking change which adds functionality)

<img width="246" alt="Screen Shot 2022-05-24 at 4 20 52 PM" src="https://user-images.githubusercontent.com/11527621/170134474-6e03a98a-aa4d-44c0-bc45-8a7b32871c9d.png">

