### PR TITLE
Fix getNumberOfFileChanges

### DIFF
--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -1,20 +1,8 @@
-import * as vscode from "vscode";
-import getFullBlame from "./getFullBlame";
-
 async function getNumberOfFileChanges(gitAPI:any, filePath:string){
-    let blameArray: string[] = [];
     let blames = await gitAPI?.repositories[0].blame(
         filePath || "."
     );
-
-    blames.split("\n").forEach((line: String) => {
-        blameArray.push(line.split(" ")[0]);
-    });
-
-    let uniqueBlames = [
-        ...new Set(blameArray),
-    ];
-   
-    return uniqueBlames.length;
+    const numberOfLinesInBlame = blames.length;
+    return numberOfLinesInBlame;
 }
 export default getNumberOfFileChanges;

--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
 import getFullBlame from "./getFullBlame";
 
-async function getNumberOfFileChanges(gitAPI:any, lineNumber:number) {
+async function getNumberOfFileChanges(gitAPI:any, filePath:string){
     let blameArray: string[] = [];
     let blames = await gitAPI?.repositories[0].blame(
-        vscode.window.activeTextEditor?.document.uri.fsPath || "."
+        filePath || "."
     );
 
     blames.split("\n").forEach((line: String) => {

--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -2,13 +2,6 @@ import * as vscode from "vscode";
 import getFullBlame from "./getFullBlame";
 
 async function getNumberOfFileChanges(gitAPI:any, lineNumber:number) {
-    let blamePromises = await getFullBlame(
-        lineNumber,
-        lineNumber,
-        vscode.window.activeTextEditor?.document.uri.fsPath,
-        gitAPI
-    );
-
     let blameArray: string[] = [];
     let blames = await gitAPI?.repositories[0].blame(
         vscode.window.activeTextEditor?.document.uri.fsPath || "."

--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import getFullBlame from "./getFullBlame";
 
-async function getNumberOfLineChanges(gitAPI:any, lineNumber:number) {
+async function getNumberOfFileChanges(gitAPI:any, lineNumber:number) {
     let blamePromises = await getFullBlame(
         lineNumber,
         lineNumber,
@@ -24,4 +24,4 @@ async function getNumberOfLineChanges(gitAPI:any, lineNumber:number) {
    
     return uniqueBlames.length;
 }
-export default getNumberOfLineChanges;
+export default getNumberOfFileChanges;

--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -2,7 +2,13 @@ async function getNumberOfFileChanges(gitAPI:any, filePath:string){
     let blames = await gitAPI?.repositories[0].blame(
         filePath || "."
     );
-    const numberOfLinesInBlame = blames.length;
-    return numberOfLinesInBlame;
+    let commitHashArray = [] as String[];
+    let splitBlames = blames.split("\n").map((line:string) => {
+        commitHashArray.push(line.split(" ")[0]);
+    });
+
+    // get number of unique entries in commitHashArray
+    let uniqueCommitHashArray = [...new Set(commitHashArray)];
+    return uniqueCommitHashArray.length;
 }
 export default getNumberOfFileChanges;

--- a/src/utils/getNumberOfLineChanges.ts
+++ b/src/utils/getNumberOfLineChanges.ts
@@ -8,17 +8,20 @@ async function getNumberOfLineChanges(gitAPI:any, lineNumber:number) {
         vscode.window.activeTextEditor?.document.uri.fsPath,
         gitAPI
     );
-    return Promise.allSettled(blamePromises).then((results) => {
-        let blames: string[] = [];
-        results.forEach((result) => {
-            if (result.status === "fulfilled") {
-                blames.push(result.value);
-            } else {
-                blames.push(result.reason);
-            }
-        });
 
-        return blames.length;
+    let blameArray: string[] = [];
+    let blames = await gitAPI?.repositories[0].blame(
+        vscode.window.activeTextEditor?.document.uri.fsPath || "."
+    );
+
+    blames.split("\n").forEach((line: String) => {
+        blameArray.push(line.split(" ")[0]);
     });
+
+    let uniqueBlames = [
+        ...new Set(blameArray),
+    ];
+   
+    return uniqueBlames.length;
 }
 export default getNumberOfLineChanges;


### PR DESCRIPTION
## Description
We want to display the number of line changes a given line has on the new context box. A high number can tell us that such file or block of code has changed its business logic a lot, therefore needs to be disambiguated. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  

## Notes
I switched over from the previous approach which was based on getFullBlame, to one that's based on getArrayOfSHAs. The previous approach was always giving us a result of "1". 

A caveat is that we're currently showing the same result for all the file (it would be more of a getNumberOfFileChanges), for some reason it's not running the blame per line despite giving it a range. Any clue? 

Regardless, I would put this on the box and later improve. 