### PR TITLE
Added declaration to use blame with right click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [1.3.1]
 - Added a newsletter section
 - Commit history table (blame) is now sorted by commit date, newest first
+- Added right click to get blame
 
 ## [1.3.0]
 - Added a hover to activate the extension

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
         {
           "command": "watermelon.start",
           "when": "editorHasSelection"
+        },
+        {
+          "command": "watermelon.blame",
+          "when": "editorHasSelection"
         }
       ]
     }


### PR DESCRIPTION
## Description
Allows getting blame on right click when there's selection.
## Type of change

- [x] New feature (non-breaking change which adds functionality)  

![image](https://user-images.githubusercontent.com/11527621/171910529-5382642e-1d11-48f5-866d-a1372aaa8fe8.png)
