### PR TITLE
Get docs for file on context box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.3.2]
-- Added button inside the context box to get the relevant docs for each file
 ## [1.3.1]
 - Added a newsletter section
 - Commit history table (blame) is now sorted by commit date, newest first
@@ -15,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added a hover to activate the extension
 - _BETA_ Launched browser version for vscode web (and github.dev)
 - Will now *not* bundle our internal docs
+- Added button inside the context box to get the relevant docs for each file
 
 ## [1.2.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.3.2]
+- Added button inside the context box to get the relevant docs for each file
 ## [1.3.1]
 - Added a newsletter section
 - Commit history table (blame) is now sorted by commit date, newest first

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,9 +83,16 @@ export async function activate(context: vscode.ExtensionContext) {
       const content = new vscode.MarkdownString(
         `[Understand the code context](${startCommandUri}) with Watermelon 🍉`
       );
+      const docsCommandUri = vscode.Uri.parse(
+        `command:watermelon.docs?${encodeURIComponent(JSON.stringify(args))}`
+      );
       content.appendMarkdown(`\n\n`);
       content.appendMarkdown(
         `[View the history for this line](${blameCommandUri}) with Watermelon 🍉`
+      );
+      content.appendMarkdown(`\n\n`);
+      content.appendMarkdown(
+        `[Get the docs for this file](${docsCommandUri}) with Watermelon 🍉`
       );
       content.supportHtml = true;
       content.isTrusted = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ export async function activate(context: vscode.ExtensionContext) {
         `[Understand the code context](${startCommandUri}) with Watermelon 🍉`
       );
       const docsCommandUri = vscode.Uri.parse(
-        `command:watermelon.docs?${encodeURIComponent(JSON.stringify(args))}`
+        `command:watermelon.docs?`
       );
       content.appendMarkdown(`\n\n`);
       content.appendMarkdown(


### PR DESCRIPTION
## Description
Gets the relevant docs for each file when clicking the new button inside the context box. 

The opened markdown file gets done so in a split-view fashion. This file is the one that will be written via the daily update interface. 

## Type of change
- [ x] New feature (non-breaking change which adds functionality)  
