### PR TITLE
Added params to command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,14 +208,13 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand("watermelon.blame", async () => {
+    vscode.commands.registerCommand("watermelon.blame", async (startLine = undefined, endLine = undefined) => {
       vscode.commands.executeCommand("watermelon.show");
       provider.sendMessage({
         command: "loading",
       });
-      localUser = await getLocalUser();
       octokit = await credentials.getOctokit();
-      let uniqueBlames = await getBlame(gitAPI);
+      let uniqueBlames = await getBlame(gitAPI, startLine, endLine);
       provider.sendMessage({
         command: "blame",
         data: uniqueBlames,


### PR DESCRIPTION
## Description
The params were removed as per #280 and it tried blaming with no selection.
It now takes the hovered line as parameter to run the blame.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  

