### PR TITLE
Create getNumberOfFileChanges.ts

### DIFF
--- a/src/utils/getNumberOfFileChanges.ts
+++ b/src/utils/getNumberOfFileChanges.ts
@@ -1,0 +1,20 @@
+export default async function getNumberOfFileChanges(
+  filePath: string,
+  gitAPI: any | undefined
+): Promise<number> {
+  let blame = await gitAPI?.repositories[0].blame(filePath);
+
+  let blameLines = blame?.split("\n");
+  let commits = blameLines.map((line: String) => line.split(" ")[0]);
+  let commitCount = 1;
+  //count each commit different from the one before
+  for (let i = 1; i < commits.length; i++) {
+    if (commits[i] !== commits[i - 1]) {
+      commitCount++;
+    }
+  }
+
+  console.log(commitCount);
+
+  return commitCount;
+}


### PR DESCRIPTION
## Description
This file allows counting as you would with the blame github feature.
Tested on [Supabase gitignore](https://github.com/supabase/supabase/blame/master/.gitignore), returning correctly 21.
Tested on [Supabase docs](https://github.com/supabase/supabase/blame/master/web/docs/guides/api/generating-types.mdx)showing correctly 14.
## Type of change

- [x] New feature (non-breaking change which adds functionality)  

## Notes
A few optimizations are available as to not navigate more than once the array, but it's fast enough.