### PR TITLE
Add codeblock back to vscode.commands.registerCommand( )

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,14 +215,15 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand("watermelon.blame", async () => {
+    vscode.commands.registerCommand("watermelon.blame", 
+    async (startLine = undefined, endLine = undefined) => {
       vscode.commands.executeCommand("watermelon.show");
       provider.sendMessage({
         command: "loading",
       });
-      localUser = await getLocalUser();
       octokit = await credentials.getOctokit();
-      let uniqueBlames = await getBlame(gitAPI);
+      let uniqueBlames = [];
+      uniqueBlames = await getBlame(gitAPI, startLine, endLine);
       provider.sendMessage({
         command: "blame",
         data: uniqueBlames,


### PR DESCRIPTION
## Description
We wanna show the commit history results when clicking the button on hover. 

It used to work before #280. I'm reverting to add the codeblock that was there. The one that passes start and endlines as a parameter and calls getBlame with such. 

It's still not working and that's why I'm sending it as a draft PR. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  

## Notes
If you print the uniqueBlames array, it does print a set of commit hashes. 