### PR TITLE
add keybindigns for watermelon.start and watermelon.blame when there's text focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Watermelon comes with a few commands that you can run from VS Code's Command Pal
 | `watermelon.blame` | Get the commit history of the selected block of code     |
 | `watermelon.show` | Reveal the extension     |
 
+## Shortcuts
+
+As an alternative, you can use the following shortcuts:
+
+- `Ctrl+Shift+C` (`Cmd+Shift+C` on Mac) for running the `watermelon.start` command
+- `Ctrl+Shift+H` (`Cmd+Shift+C` on Mac) for running the `watermelon.blame` command
+
 ## Contributing
 
 Check out [Contributing.md](CONTRIBUTING.md) and be aware of the [Code of Conduct](CODE_OF_CONDUCT.md)!

--- a/package.json
+++ b/package.json
@@ -100,7 +100,21 @@
           "when": "editorHasSelection"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "watermelon.start",
+        "key": "ctrl+shift+C",
+        "mac": "cmd+shift+C",
+        "when": "editorHasSelection"
+      },
+      {
+        "command": "watermelon.blame",
+        "key": "ctrl+shift+H",
+        "mac": "cmd+shift+H",
+        "when": "editorHasSelection"
+      }
+    ]
   },
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add keybindigns for watermelon.start and watermelon.blame when there's text focus
Solves: https://github.com/watermelontools/wm-extension/issues/140

## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [x] New feature (non-breaking change which adds functionality)  
- [x] Documentation update

