### PR TITLE
Add command to recommend extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.4.6]
+
+- New `watermelon.recommend` command, to recommend a watermelon to everyone on the repo
+
 ## [1.4.5]
 
 - Better daily summary UI

--- a/README.md
+++ b/README.md
@@ -61,23 +61,24 @@ Alternatively, you can search for "Watermelon" in VS Code's built-in extension m
 
 Watermelon comes with a few commands that you can run from VS Code's Command Palette. The result is exactly the same as running a Watermelon query with the green button. Results sit in your sidebar.
 
-| Command            | Description                                              |
-| :----------------- | :------------------------------------------------------- |
-| `watermelon.start` | Get the historical context of the selected block of code |
-| `watermelon.blame` | Get the commit history of the selected block of code     |
-| `watermelon.show`  | Reveal the extension                                     |
+| Command                | Description                                              |
+| :--------------------- | :------------------------------------------------------- |
+| `watermelon.start`     | Get the historical context of the selected block of code |
+| `watermelon.blame`     | Get the commit history of the selected block of code     |
+| `watermelon.show`      | Reveal the extension                                     |
+| `watermelon.recommend` | Add the extension to the list of recommended             |
 
 ## Shortcuts
 
 As an alternative, you can use the following shortcuts:
 
-- `Ctrl+Shift+C` (`Cmd+Shift+C` on Mac) to view Pull Requests 
+- `Ctrl+Shift+C` (`Cmd+Shift+C` on Mac) to view Pull Requests
 - `Ctrl+Shift+H` (`Cmd+Shift+C` on Mac) to view the Commit History
 
 ## Hover
 
-When hovering over code, Watermelon will offer to run the actions. 
-It will offer the latest commit information, including its title, author and date. 
+When hovering over code, Watermelon will offer to run the actions.
+It will offer the latest commit information, including its title, author and date.
 It will also show how many times the hovered file has changed.
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
         "command": "watermelon.blame",
         "title": "Get Commit History with Watermelon",
         "category": "watermelon"
+      },
+      {
+        "command": "watermelon.recommend",
+        "title": "Add Watermelon to recommended extensions",
+        "category": "watermelon"
       }
     ],
     "views": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,4 @@ export const WATERMELON_PULLS_COMMAND = "watermelon.start";
 export const WATERMELON_HISTORY_COMMAND = "watermelon.blame";
 export const WATERMELON_SELECT_COMMAND = "watermelon.select";
 export const WATERMELON_MULTI_SELECT_COMMAND = "watermelon.multiSelect";
+export const WATERMELON_ADD_TO_RECOMMENDED_COMMAND = "watermelon.recommend";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import statusBarItem, {
 import hover from "./utils/components/hover";
 import getDailySummary from "./utils/github/getDailySummary";
 import {
+  WATERMELON_ADD_TO_RECOMMENDED_COMMAND,
   WATERMELON_HISTORY_COMMAND,
   WATERMELON_MULTI_SELECT_COMMAND,
   WATERMELON_PULLS_COMMAND,
@@ -87,6 +88,12 @@ export async function activate(context: vscode.ExtensionContext) {
   // create the hover provider
   let wmHover = hover({ reporter });
 
+  let addToRecommendedCommandHandler = async () => {
+    vscode.commands.executeCommand(
+      "workbench.extensions.action.addExtensionToWorkspaceRecommendations",
+      "WatermelonTools.watermelon-tools"
+    );
+  };
 
   let historyCommandHandler = async (
     startLine = undefined,
@@ -231,6 +238,10 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       WATERMELON_HISTORY_COMMAND,
       historyCommandHandler
+    ),
+    vscode.commands.registerCommand(
+      WATERMELON_ADD_TO_RECOMMENDED_COMMAND,
+      addToRecommendedCommandHandler
     )
   );
 
@@ -298,7 +309,7 @@ export async function activate(context: vscode.ExtensionContext) {
       },
     });
   }
-  let repoInfo = await getRepoInfo({reporter});
+  let repoInfo = await getRepoInfo({ reporter });
   repo = repoInfo?.repo;
   owner = repoInfo?.owner;
   debugLogger(`repo: ${repo}`);


### PR DESCRIPTION
## Description
You can now add watermelon to the list of the recommended extensions from the command palette
## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  
## Notes
Should we have it in the UI?
