### PR TITLE
Replace hyperlinks with a tags that contain the hyperlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.4.7]
+
+- Hyperlinks are now clickable in the History table
+
 ## [1.4.6]
 
 - New `watermelon.recommend` command, to recommend a watermelon to everyone on the repo
 - New `watermelon.login` command, to login using GitHub from your keyboard
-- We now track every time the `watermelon.show` command is called 
+- We now track every time the `watermelon.show` command is called
 - You can now email the committer from the hover
 - Changed how the buttons on the webview work to match commands
 

--- a/media/utils/addBlametoDoc.js
+++ b/media/utils/addBlametoDoc.js
@@ -1,5 +1,6 @@
 import addActionButtons from "./addActionButtons.js";
 import dateToHumanReadable from "./dateToHumanReadable.js";
+import replaceHyperlinks from "./replaceHyperlinks.js";
 
 const addBlametoDoc = (blameArray, commitLink) => {
   addActionButtons();
@@ -37,7 +38,7 @@ const addBlametoDoc = (blameArray, commitLink) => {
         }
         </td>
         <td>${blameLine.authorName}</td>
-        <td>${blameLine.message}</td>
+        <td>${replaceHyperlinks(blameLine.message)}</td>
         <td>${dateToHumanReadable(blameLine.commitDate)}</td>
       </tr>
       `);

--- a/media/utils/replaceHyperlinks.js
+++ b/media/utils/replaceHyperlinks.js
@@ -1,0 +1,9 @@
+const replaceHyperlinks = (text) => {
+    let hyperlink = text.match(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gm)[0];
+    return text
+      .replaceAll(
+        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gm,
+        `<a href=${hyperlink}>${hyperlink}</a>`
+      );
+  };
+  export default replaceHyperlinks;

--- a/media/utils/replaceHyperlinks.js
+++ b/media/utils/replaceHyperlinks.js
@@ -1,9 +1,21 @@
 const replaceHyperlinks = (text) => {
-    let hyperlink = text.match(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gm)[0];
+    let hyperlinkArray = text.match(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gm);
+
+    let trimmedHyperlinks = [];
+
+    hyperlinkArray.forEach(element => {
+      console.log("element: ", element);
+
+      if (element.charAt(element.length - 1) === ")") {
+        let newElement = element.slice(0, -1);
+        trimmedHyperlinks.push(newElement);
+      }
+    });
+
     return text
       .replaceAll(
         /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gm,
-        `<a href=${hyperlink}>${hyperlink}</a>`
+        `<a href=${trimmedHyperlinks[0]}>${trimmedHyperlinks[0]}</a>`
       );
   };
   export default replaceHyperlinks;


### PR DESCRIPTION
## Description
There are some commit messages that contain URLs. It would be nice UX enhancement to hyperlink those. 

## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
The RegEx I found grabs the parenthesis after the URL, therefore damaging the link. Need to find a way to fix this in order to upgrade this PR from draft to regular. 
