### PR TITLE
Remove function that generates critical bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [1.4.7]
 
-- Hyperlinks are now clickable in the History table
-
 ## [1.4.6]
 
 - New `watermelon.recommend` command, to recommend a watermelon to everyone on the repo

--- a/media/utils/addBlametoDoc.js
+++ b/media/utils/addBlametoDoc.js
@@ -38,7 +38,7 @@ const addBlametoDoc = (blameArray, commitLink) => {
         }
         </td>
         <td>${blameLine.authorName}</td>
-        <td>${replaceHyperlinks(blameLine.message)}</td>
+        <td>${(blameLine.message)}</td>
         <td>${dateToHumanReadable(blameLine.commitDate)}</td>
       </tr>
       `);


### PR DESCRIPTION
## Description
Remove function that causes critical bug (the one that hyperlinks URLs on the blame table). 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ x] Chore: cleanup/renaming, etc  
- [ ] RFC 
 
## Notes
I'll leave the function file untouched (w/o calling it) to get back to this later. 
