### PR TITLE
Feature/reorganize UI

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -6,6 +6,7 @@ import setLoading from "./utils/setLoading.js";
 import removeLoading from "./utils/removeLoading.js";
 import clampCodeBlocks from "./utils/clampCodeBlocks.js";
 import addPRsToDoc from "./utils/addPRsToDoc.js";
+import addContextToDoc from "./utils/addContextToDoc.js";
 import sendMessage from "./utils/sendVSCodeMessage.js";
 import addBlametoDoc from "./utils/addBlametoDoc.js";
 import addGHUserInfo from "./utils/addGHUserInfo.js";
@@ -46,11 +47,30 @@ function handleMessage(message) {
       addDailySummary(message.data);
       break;
     case "prs":
-      webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
-      removeLoading(errorTimeout);
-      addPRsToDoc(message.data);
-      clampCodeBlocks();
+      // all the context
+      let commitLink = undefined;
+      if (message.owner && message.repo) {
+        commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
+      }
+      console.log("case prs message.data", message.data);
+      addContextToDoc(message.data, commitLink);
+
+      // // prs
+      // webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
+      // removeLoading(errorTimeout);
+      // addPRsToDoc(message.data);
+      // clampCodeBlocks();
+
+      // // blame
+      // webviewDebugLogger(`Received blame: ${JSON.stringify(message.data)}`);
+      // let commitLink = undefined;
+      // if (message.owner && message.repo) {
+      //   commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
+      // }
+      // removeLoading(errorTimeout);
+      // addBlametoDoc(message.data, commitLink);
       break;
+      // break;
     case "loading":
       webviewDebugLogger(`Received loading: ${JSON.stringify(message.data)}`);
       errorTimeout = setLoading(errorTimeout);
@@ -76,33 +96,16 @@ function handleMessage(message) {
       webviewDebugLogger(`Received session: ${JSON.stringify(message.data)}`);
       addSessionToFooter(message.data);
       break;
-    case "blame":
-      webviewDebugLogger(`Received blame: ${JSON.stringify(message.data)}`);
-      let commitLink = undefined;
-      if (message.owner && message.repo) {
-        commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
-      }
-      removeLoading(errorTimeout);
-      addBlametoDoc(message.data, commitLink);
-      break;
-    case "wholeContext":
-      console.log("case wholeContext");
-      // // PRs
-      // webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
-      // removeLoading(errorTimeout);
-      // addPRsToDoc(message.data);
-      // clampCodeBlocks();
-      // // break;
-
-      // // blame
-      // webviewDebugLogger(`Received blame: ${JSON.stringify(message.data)}`);
-      // let commitLink = undefined;
-      // if (message.owner && message.repo) {
-      //   commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
-      // }
-      // removeLoading(errorTimeout);
-      // addBlametoDoc(message.data, commitLink);
-      // break;
+    // case "blame":
+    //   console.log("case blame message.data ", message.data);
+    //   webviewDebugLogger(`Received blame: ${JSON.stringify(message.data)}`);
+    //   let commitLink = undefined;
+    //   if (message.owner && message.repo) {
+    //     commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
+    //   }
+    //   removeLoading(errorTimeout);
+    //   addBlametoDoc(message.data, commitLink);
+    //   break;
     default:
       webviewDebugLogger(
         `Received unknown command: ${JSON.stringify(message)}`
@@ -123,7 +126,6 @@ $(document).ready(function () {
   const button = document.getElementsByClassName("run-watermelon");
   const gitBlame = document.getElementsByClassName("git-blame");
   const starWMRepo = document.getElementById("starWMRepo");
-  const wholeContextButton = document.getElementsByClassName("whole-context-button");
 
   button[0].addEventListener("click", (event) => {
     sendMessage({ command: "run" });
@@ -133,9 +135,6 @@ $(document).ready(function () {
   });
   starWMRepo.addEventListener("click", (event) => {
     sendMessage({ command: "star" });
-  });
-  wholeContextButton[0].addEventListener("click", (event) => {
-    sendMessage({ command: "wholeContext" });
   });
 
 });

--- a/media/main.js
+++ b/media/main.js
@@ -85,6 +85,24 @@ function handleMessage(message) {
       removeLoading(errorTimeout);
       addBlametoDoc(message.data, commitLink);
       break;
+    case "wholeContext":
+      console.log("case wholeContext");
+      // // PRs
+      // webviewDebugLogger(`Received prs: ${JSON.stringify(message.data)}`);
+      // removeLoading(errorTimeout);
+      // addPRsToDoc(message.data);
+      // clampCodeBlocks();
+      // // break;
+
+      // // blame
+      // webviewDebugLogger(`Received blame: ${JSON.stringify(message.data)}`);
+      // let commitLink = undefined;
+      // if (message.owner && message.repo) {
+      //   commitLink = `https://github.com/${message.owner}/${message.repo}/commit/`;
+      // }
+      // removeLoading(errorTimeout);
+      // addBlametoDoc(message.data, commitLink);
+      // break;
     default:
       webviewDebugLogger(
         `Received unknown command: ${JSON.stringify(message)}`
@@ -101,9 +119,12 @@ $(document).ready(function () {
     vscode.setState(message);
     handleMessage(message);
   });
+
   const button = document.getElementsByClassName("run-watermelon");
   const gitBlame = document.getElementsByClassName("git-blame");
   const starWMRepo = document.getElementById("starWMRepo");
+  const wholeContextButton = document.getElementsByClassName("whole-context-button");
+
   button[0].addEventListener("click", (event) => {
     sendMessage({ command: "run" });
   });
@@ -113,4 +134,8 @@ $(document).ready(function () {
   starWMRepo.addEventListener("click", (event) => {
     sendMessage({ command: "star" });
   });
+  wholeContextButton[0].addEventListener("click", (event) => {
+    sendMessage({ command: "wholeContext" });
+  });
+
 });

--- a/media/utils/addActionButtons.js
+++ b/media/utils/addActionButtons.js
@@ -5,6 +5,14 @@ const addActionButtons = () => {
   $("#ghHolder").append(
     `
     <div class="anim-fade-in">
+      <p>Master button</p>
+      <button class="whole-context-button btn btn-primary" type="button">Get Code Context</button>
+    </div>
+        `
+  );
+  $("#ghHolder").append(
+    `
+    <div class="anim-fade-in">
       <p>We will fetch the commit history for you to understand the context of the code</p>
       <button class="git-blame btn btn-primary" type="button">View Commit History</button>
     </div>
@@ -24,6 +32,9 @@ const addActionButtons = () => {
   });
   $(".git-blame").on("click", (event) => {
     sendMessage({ command: "blame" });
+  });
+  $(".whole-context-button").on("click", (event) => {
+    sendMessage({ command: "wholeContext" });
   });
 };
 export default addActionButtons;

--- a/media/utils/addActionButtons.js
+++ b/media/utils/addActionButtons.js
@@ -1,28 +1,27 @@
 import sendMessage from "./sendVSCodeMessage.js";
 
 const addActionButtons = () => {
-  $("#ghHolder").append(`<p>Higlight a piece of code to start.</p>`);
-  $("#ghHolder").append(
-    `
-    <div class="anim-fade-in">
-      <p>Master button</p>
-      <button class="whole-context-button btn btn-primary" type="button">Get Code Context</button>
-    </div>
-        `
-  );
-  $("#ghHolder").append(
-    `
-    <div class="anim-fade-in">
-      <p>We will fetch the commit history for you to understand the context of the code</p>
-      <button class="git-blame btn btn-primary" type="button">View Commit History</button>
-    </div>
-        `
-  );
+  // $("#ghHolder").append(
+  //   `
+  //   <div class="anim-fade-in">
+  //     <p>Master button</p>
+  //     <button class="whole-context-button btn btn-primary" type="button">Get Code Context</button>
+  //   </div>
+  //       `
+  // );
+  // $("#ghHolder").append(
+  //   `
+  //   <div class="anim-fade-in">
+  //     <p>We will fetch the commit history for you to understand the context of the code</p>
+  //     <button class="git-blame btn btn-primary" type="button">View Commit History</button>
+  //   </div>
+  //       `
+  // );
   $("#ghHolder").append(
     `
     <div class="anim-fade-in">
       <p>Click this button to enrich your code with relevant information from GitHub:</p>
-      <button class="run-watermelon btn btn-primary" type="button">View Pull Requests</button>
+      <button class="run-watermelon btn btn-primary" type="button">Get Code Context</button>
     </div>
     `
   );

--- a/media/utils/addBlametoDoc.js
+++ b/media/utils/addBlametoDoc.js
@@ -38,7 +38,7 @@ const addBlametoDoc = (blameArray, commitLink) => {
         }
         </td>
         <td>${blameLine.authorName}</td>
-        <td>${replaceHyperlinks(blameLine.message)}</td>
+        <td>${(blameLine.message)}</td>
         <td>${dateToHumanReadable(blameLine.commitDate)}</td>
       </tr>
       `);

--- a/media/utils/addContextToDoc.js
+++ b/media/utils/addContextToDoc.js
@@ -4,58 +4,28 @@ import dateToHumanReadable from "./dateToHumanReadable.js";
 import parseComments from "./parseComments.js";
 import addActionButtons from "./addActionButtons.js";
 const addContextToDoc = (prs, commitLink) => {
-
-
-    // Add blame to doc
-
-    // addActionButtons();
-    // $("#ghHolder").append(`
-    //   <h3>Commits</h3>
-    //   `);
-    // $("#ghHolder").append(`
-    //   <table class="Box anim-fade-in">
-    //     <thead class="Box-header">
-    //       <tr>
-    //         <th>Commit</th>
-    //         <th>Author</th>
-    //         <th>Message</th>
-    //         <th>Date</th>
-    //       </tr>
-    //     </thead>
-    //     <tbody class="blame-rows">
-    //     </tbody>
-    //   </table>
-    //   `);
-    // //sort array by date, newest first
-    // blameArray.sort((a, b) => {
-    //   return new Date(b.commitDate) - new Date(a.commitDate);
-    // });
-    // blameArray.forEach((blameLine, index) => {
-    //   $(".blame-rows").append(`
-    //     <tr ${index % 2 === 1 ? 'class="Box-row--gray"' : ""}>
-    //       <td>
-    //       ${
-    //         commitLink
-    //           ? `<a href='${commitLink}${blameLine?.hash}'>
-    //             ${blameLine?.hash?.slice(0, 7)}
-    //             </a>`
-    //           : blameLine?.hash?.slice(0, 7)
-    //       }
-    //       </td>
-    //       <td>${blameLine.authorName}</td>
-    //       <td>${(blameLine.message)}</td>
-    //       <td>${dateToHumanReadable(blameLine.commitDate)}</td>
-    //     </tr>
-    //     `);
-    // });
-
-    // Add PRs to Doc
-
-    console.log("message, commitlink", prs, commitLink);
+  console.log("message, commitlink", prs, commitLink);
+  
   addActionButtons();
   $("#ghHolder").append(`
   <h3>Code Context</h3>
   `);
+
+    // Latest commit message
+    $("#ghHolder").append(`
+    <table class="Box anim-fade-in">
+      <thead class="Box-header">
+        <tr>
+          <th>Commit</th>
+          <th>Author</th>
+          <th>Message</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody class="blame-rows">
+      </tbody>
+    </table>
+    `);
 
     // Most Relevant PR
     $("#ghHolder").append(`

--- a/media/utils/addContextToDoc.js
+++ b/media/utils/addContextToDoc.js
@@ -1,0 +1,113 @@
+import replaceIssueLinks from "./replaceIssueLinks.js";
+import replaceUserTags from "./replaceUserTags.js";
+import dateToHumanReadable from "./dateToHumanReadable.js";
+import parseComments from "./parseComments.js";
+import addActionButtons from "./addActionButtons.js";
+const addContextToDoc = (prs, commitLink) => {
+
+
+    // Add blame to doc
+
+    // addActionButtons();
+    // $("#ghHolder").append(`
+    //   <h3>Commits</h3>
+    //   `);
+    // $("#ghHolder").append(`
+    //   <table class="Box anim-fade-in">
+    //     <thead class="Box-header">
+    //       <tr>
+    //         <th>Commit</th>
+    //         <th>Author</th>
+    //         <th>Message</th>
+    //         <th>Date</th>
+    //       </tr>
+    //     </thead>
+    //     <tbody class="blame-rows">
+    //     </tbody>
+    //   </table>
+    //   `);
+    // //sort array by date, newest first
+    // blameArray.sort((a, b) => {
+    //   return new Date(b.commitDate) - new Date(a.commitDate);
+    // });
+    // blameArray.forEach((blameLine, index) => {
+    //   $(".blame-rows").append(`
+    //     <tr ${index % 2 === 1 ? 'class="Box-row--gray"' : ""}>
+    //       <td>
+    //       ${
+    //         commitLink
+    //           ? `<a href='${commitLink}${blameLine?.hash}'>
+    //             ${blameLine?.hash?.slice(0, 7)}
+    //             </a>`
+    //           : blameLine?.hash?.slice(0, 7)
+    //       }
+    //       </td>
+    //       <td>${blameLine.authorName}</td>
+    //       <td>${(blameLine.message)}</td>
+    //       <td>${dateToHumanReadable(blameLine.commitDate)}</td>
+    //     </tr>
+    //     `);
+    // });
+
+    // Add PRs to Doc
+
+    console.log("message, commitlink", prs, commitLink);
+  addActionButtons();
+  $("#ghHolder").append(`
+  <h3>Code Context</h3>
+  `);
+
+    // Most Relevant PR
+    $("#ghHolder").append(`
+    <div class="anim-fade-in">
+
+        <summary class="pr-title">
+          <div>
+            <div class="details-state">
+              <div class="icon-holder">
+                <i class='codicon codicon-chevron-right'></i>
+                <i class='codicon codicon-chevron-down'></i>
+              </div>
+              <a 
+              href="${prs[0].url}" target="_blank" title="View this PR on github">${
+              prs[0].title
+              }</a>
+            </div>
+          </div>
+          <div class="icon-holder">${
+            prs[0].state === "closed"
+            ? "<i class='codicon codicon-git-merge'></i>"
+              : "<i class='codicon codicon-git-pull-request'></i>"
+          }
+          </div>
+      </summary>
+        <div class="Box">
+        <div class="Box-header d-flex">
+            <p class="pr-poster" title="View this user on github">
+              <a class="pr-author-combo" href="${
+                prs[0].userLink
+              }"><img class='pr-author-img' src="${prs[0].userImage}" />${
+               prs[0].user
+              } </a>
+            </p>
+            <p class="pr-date">
+                on ${dateToHumanReadable(prs[0].created_at)}
+            </p>
+        </div>
+          <div class="Box-body">
+            ${
+              prs[0]?.body
+                ? (
+                    replaceUserTags(marked.parse(prs[0].body, { gfm: true, breaks: true }))
+                  )
+                : ""
+            }
+          </div>
+          ${(prs[0].comments)}
+        </div>
+      </details>
+    </div>
+      `);
+};
+
+export default addContextToDoc;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "onCommand:watermelon.start",
     "onCommand:watermelon.blame",
     "onCommand:watermelon.show",
+    "onCommand:watermelon.wholeContext",
     "onWebviewPanel:watermelon",
     "onStartupFinished"
   ],
@@ -71,6 +72,11 @@
       {
         "command": "watermelon.recommend",
         "title": "Add Watermelon to recommended extensions",
+        "category": "watermelon"
+      },
+      {
+        "command": "watermelon.wholeContext",
+        "title": "Get the whole code context with Watermelon",
         "category": "watermelon"
       }
     ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const EXTENSION_ID = "WatermelonTools.watermelon-tools";
 export const WATERMELON_SHOW_COMMAND = "watermelon.show";
 export const WATERMELON_PULLS_COMMAND = "watermelon.start";
 export const WATERMELON_HISTORY_COMMAND = "watermelon.blame";
+export const WATERMELON_WHOLE_CONTEXT_COMMAND = "watermelon.wholeContext";
 export const WATERMELON_SELECT_COMMAND = "watermelon.select";
 export const WATERMELON_MULTI_SELECT_COMMAND = "watermelon.multiSelect";
 export const WATERMELON_LOGIN_COMMAND = "watermelon.login";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import getDailySummary from "./utils/github/getDailySummary";
 import {
   WATERMELON_ADD_TO_RECOMMENDED_COMMAND,
   WATERMELON_HISTORY_COMMAND,
+  WATERMELON_WHOLE_CONTEXT_COMMAND,
   WATERMELON_LOGIN_COMMAND,
   WATERMELON_MULTI_SELECT_COMMAND,
   WATERMELON_OPEN_LINK_COMMAND,
@@ -120,6 +121,14 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   };
 
+  let wholeContextCommandHandler = async() => {
+    console.log("whole context command handler");
+
+    provider.sendMessage({
+      command: "wholeContext"
+    });
+  };
+
   let historyCommandHandler = async (
     startLine = undefined,
     endLine = undefined
@@ -136,6 +145,7 @@ export async function activate(context: vscode.ExtensionContext) {
       repo,
     });
   };
+
   let prsCommandHandler = async (
     startLine = undefined,
     endLine = undefined
@@ -280,6 +290,10 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       WATERMELON_HISTORY_COMMAND,
       historyCommandHandler
+    ),
+    vscode.commands.registerCommand(
+      WATERMELON_WHOLE_CONTEXT_COMMAND,
+      wholeContextCommandHandler,
     ),
     vscode.commands.registerCommand(
       WATERMELON_LOGIN_COMMAND,

--- a/src/utils/vscode/getInitialHTML.ts
+++ b/src/utils/vscode/getInitialHTML.ts
@@ -111,13 +111,7 @@ export default function getInitialHTML(
         <p>Help us by <a href="https://github.com/watermelontools/wm-extension">⭐starring Watermelon on GitHub</a></p>
         <br/>
         <div id="ghHolder">
-           <button class='whole-context-button btn btn-primary' type='button'>Get Code Context</button>
-           <p>Higlight a piece of code to start.</p>
-           <p>We will fetch the commit history for you to understand the context of the code</p>
-           <button class='git-blame btn btn-primary' type='button'>View Commit History</button>
-           <p>Click this button to enrich your code with relevant information from GitHub:</p>
-           <button class='run-watermelon btn btn-primary' type='button'>View Pull Requests</button>
-           <p>Alternatively, you can <a href="https://github.com/watermelontools/wm-extension#commands">run with our watermelon.start command</a>, by selecting and right clicking on the selection or by using our <a href="https://github.com/watermelontools/wm-extension#shortcuts"><kbd>keyboard</kbd> shortcuts</a>.</p>
+           <button class='run-watermelon btn btn-primary' type='button'>Get Code Context</button>
         </div>
         <h2>Daily Summary</h2>
         <div id="dailySummary"></div>

--- a/src/utils/vscode/getInitialHTML.ts
+++ b/src/utils/vscode/getInitialHTML.ts
@@ -111,6 +111,7 @@ export default function getInitialHTML(
         <p>Help us by <a href="https://github.com/watermelontools/wm-extension">⭐starring Watermelon on GitHub</a></p>
         <br/>
         <div id="ghHolder">
+           <button class='whole-context-button btn btn-primary' type='button'>Get Code Context</button>
            <p>Higlight a piece of code to start.</p>
            <p>We will fetch the commit history for you to understand the context of the code</p>
            <button class='git-blame btn btn-primary' type='button'>View Commit History</button>


### PR DESCRIPTION
## Description
Because our users say that they're annoyed by so much information at once, we're reorganizing the UI to show a single commit message and a single PR at once. 

In this draft PR I'm creating a new file (addContextToDoc.js) that intends to receive a message that renders both one item on the blame table, a PR, and (soon) a Jira ticket. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
General question: Is this the correct approach? What do you think?

Specific questions:
- message.data is different per command. I see that on main.js there is a handleMessage function that depending on the command in the message, does somethinng different. However, I haven't been able to understand where message mutates depending on the command. Can you explain this so that I can retrieve both the blameArray and prs on addContextToDoc.js? (If it is indeed, the correct approach). 
- I see on extension.ts we have various command handlers. Should we combine both commands? Or treat them as something separate? 
