### PR TITLE
Use marked to parse commit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [1.4.7]
 
+- Commit messages now allow markdown, including lists
+
 ## [1.4.6]
 
 - New `watermelon.recommend` command, to recommend a watermelon to everyone on the repo

--- a/media/utils/addBlametoDoc.js
+++ b/media/utils/addBlametoDoc.js
@@ -38,7 +38,7 @@ const addBlametoDoc = (blameArray, commitLink) => {
         }
         </td>
         <td>${blameLine.authorName}</td>
-        <td>${(blameLine.message)}</td>
+        <td>${marked.parse(blameLine.message)}</td>
         <td>${dateToHumanReadable(blameLine.commitDate)}</td>
       </tr>
       `);


### PR DESCRIPTION
## Description
Allows markdown in commit messages. 
This allows links, and lists
## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  
## Notes
### Before
<img width="957" alt="Screen Shot 2022-07-27 at 3 09 24 PM" src="https://user-images.githubusercontent.com/11527621/181362943-6a55a207-9e48-45bf-b139-fa4fd4d22dbd.png">

### After
<img width="929" alt="Screen Shot 2022-07-27 at 3 08 57 PM" src="https://user-images.githubusercontent.com/11527621/181362859-f527da50-d308-4011-81ca-c139918644bb.png">

