### PR TITLE
Remove GH sponsors, remove Slack badge, and add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 [![Report an issue](https://img.shields.io/badge/-Report%20an%20issue-critical)](https://github.com/watermelontools/wm-extension/issues)
 
 [![GitHub Repo stars](https://img.shields.io/github/stars/watermelontools/wm-extension?style=flat-square)](https://github.com/watermelontools/wm-extension/stargazers)
+
 [![Contributors](https://img.shields.io/github/contributors/watermelontools/wm-extension?style=flat-square)](https://github.com/watermelontools/wm-extension/graphs/contributors)
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/watermelontools?color=db61a2)](https://github.com/sponsors/watermelontools)
+
 [![Twitter Follow](https://img.shields.io/twitter/follow/WatermelonTools?style=flat-square)](https://twitter.com/intent/follow?screen_name=WatermelonTools)
+
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/WatermelonTools.watermelon-tools?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=WatermelonTools.watermelon-tools&ssr=false)
+
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/WatermelonTools.watermelon-tools?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=WatermelonTools.watermelon-tools&ssr=false)
+
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/WatermelonTools.watermelon-tools?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=WatermelonTools.watermelon-tools&ssr=false#review-details)
-[![Slack](https://img.shields.io/badge/Slack%20Community-Watermelon-brightgreen)](https://join.slack.com/t/watermelonusers/shared_invite/zt-15bjnr3rm-uoz8QMb1HMVB4Qywvq94~Q)
+
+[![Discord](https://img.shields.io/discord/933846506438541492?style=flat-square)](discord.gg/xNDFXx9447)
 
 Watermelon is an **open-source** integration between **GitHub** and **Visual Studio Code** to help developers go beyond Git Blame. Watermelon makes you an expert on any file instantly by running `git blame` for you and telling you why a block of code was written that way by someone else.
 


### PR DESCRIPTION
## Description
Removed GH Sponsors and Slack badges. Added Discord badges. 

Discord is not our focus and the number '0' looks sad. Changed Slack for Discord because we're focusing on Discord again. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  
