### PR TITLE
Add command to show talk 2 cto link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "watermelon" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.5.2]
+
+- Will show the user a prompt to talk to the CTO every third use
+
 ## [1.5.1]
 
 - Allows the user to see more than one commit and PR when requested

--- a/media/main.js
+++ b/media/main.js
@@ -33,7 +33,7 @@ Sentry.init({
 });
 
 function handleMessage(message) {
-  webviewDebugLogger(message.command, true);
+  webviewDebugLogger(message.command);
   switch (message.command) {
     case "user":
       webviewDebugLogger(`Received user: ${JSON.stringify(message.user)}`);
@@ -85,7 +85,7 @@ function handleMessage(message) {
       break;
     case "talkToCTO":
       $(".action-buttons").append(
-        `<a href="https://cal.pv.dev/esteban-dalel-watermelon-tools/half-hour-chat">Talk to the CTO</a>`
+        `<p>Wanna give us feedback? <a href="https://cal.pv.dev/esteban-dalel-watermelon-tools/half-hour-chat">Talk to the CTO</a></p>`
       );
 
       break;

--- a/media/main.js
+++ b/media/main.js
@@ -33,7 +33,7 @@ Sentry.init({
 });
 
 function handleMessage(message) {
-  webviewDebugLogger(`Received message: ${JSON.stringify(message)}`);
+  webviewDebugLogger(message.command, true);
   switch (message.command) {
     case "user":
       webviewDebugLogger(`Received user: ${JSON.stringify(message.user)}`);
@@ -82,6 +82,12 @@ function handleMessage(message) {
     case "session":
       webviewDebugLogger(`Received session: ${JSON.stringify(message.data)}`);
       addSessionToFooter(message.data);
+      break;
+    case "talkToCTO":
+      $(".action-buttons").append(
+        `<a href="https://cal.pv.dev/esteban-dalel-watermelon-tools/half-hour-chat">Talk to the CTO</a>`
+      );
+
       break;
     default:
       webviewDebugLogger(

--- a/media/utils/addActionButtons.js
+++ b/media/utils/addActionButtons.js
@@ -5,8 +5,10 @@ const addActionButtons = () => {
   $("#ghHolder").append(
     `
     <div class="anim-fade-in">
+    <div class="action-buttons">
       <p>Click this button to enrich your code with relevant information from GitHub:</p>
       <button class="run-watermelon btn btn-primary" type="button">Get Code Context</button>
+    </div>
     </div>
     `
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,11 +231,11 @@ export async function activate(context: vscode.ExtensionContext) {
   };
   let showCommandHandler = async () => {
     // @ts-ignore
-    context.globalState.update("ja", context.globalState.get("ja") + 1);
+    context.globalState.update("openSidebarCount", context.globalState.get("openSidebarCount") + 1);
     if (
-      context.globalState.get<number>("ja") &&
+      context.globalState.get<number>("openSidebarCount") &&
       // @ts-ignore
-      context.globalState.get<Number>("ja") % 3 === 0
+      context.globalState.get<Number>("openSidebarCount") % 3 === 0
     ) {
       provider.sendMessage({
         command: "talkToCTO",
@@ -306,7 +306,7 @@ export async function activate(context: vscode.ExtensionContext) {
     debugLogger(`githubUserInfo: ${JSON.stringify(githubUserInfo)}`);
     let username = githubUserInfo.login;
     context.globalState.update("startupState", { username });
-    context.globalState.update("ja", 0);
+    context.globalState.update("openSidebarCount", 0);
     reporter?.sendTelemetryEvent("githubUserInfo", { username });
     let isStarred = await checkIfUserStarred({ octokit });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,6 +230,17 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   };
   let showCommandHandler = async () => {
+    // @ts-ignore
+    context.globalState.update("ja", context.globalState.get("ja") + 1);
+    if (
+      context.globalState.get<number>("ja") &&
+      // @ts-ignore
+      context.globalState.get<Number>("ja") % 3 === 0
+    ) {
+      provider.sendMessage({
+        command: "talkToCTO",
+      });
+    }
     vscode.commands.executeCommand("watermelon.sidebar.focus");
     reporter?.sendTelemetryEvent("showCommand");
   };
@@ -295,6 +306,7 @@ export async function activate(context: vscode.ExtensionContext) {
     debugLogger(`githubUserInfo: ${JSON.stringify(githubUserInfo)}`);
     let username = githubUserInfo.login;
     context.globalState.update("startupState", { username });
+    context.globalState.update("ja", 0);
     reporter?.sendTelemetryEvent("githubUserInfo", { username });
     let isStarred = await checkIfUserStarred({ octokit });
 


### PR DESCRIPTION
## Description
Will now show a lingk to the CTO calendar under the get context button every third usage
## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  
## Notes
<!--  This is a great place to add images or possible improvements -->
<!--  Remember you can use "Closes #106" to close Issue 106 (or any number) -->
