### PR TITLE
Improve hover context box

### DIFF
--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -38,8 +38,9 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
         )}`
       );
       const content = new vscode.MarkdownString(
-        `$(git-pull-request)[Understand the code context](${startCommandUri}) with Watermelon 🍉`
-      );
+        `$(github-inverted)[ View the code context](${startCommandUri}) with Watermelon 🍉`
+        );
+      
       content.appendMarkdown(`\n\n`);
       content.appendMarkdown(
         `The latest commit was made by [$(mail)${
@@ -48,8 +49,14 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
         `
       );
       content.appendMarkdown(`\n`);
-      content.appendMarkdown(latestCommit.message);
+      content.appendMarkdown(latestCommit.message.split("\n")[0]);
       content.appendMarkdown(`\n\n`);
+      content.appendMarkdown(latestCommit.message.split("\n")[1] || "");
+      content.appendMarkdown(`\n\n`);
+      if (latestCommit.message.split("\n").length > 2) {
+        content.appendMarkdown(`(git-commit)[See the other ${latestCommit.message.split("\n").length - 2} commit message lines](${startCommandUri})`);
+        content.appendMarkdown(`\n\n`);
+      }
       content.appendMarkdown(
         `This file has changed ${numberOfFileChanges} time${getPlural(
           numberOfFileChanges

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -54,7 +54,7 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
       content.appendMarkdown(latestCommit.message.split("\n")[1] || "");
       content.appendMarkdown(`\n\n`);
       if (latestCommit.message.split("\n").length > 2) {
-        content.appendMarkdown(`(git-commit)[See the other ${latestCommit.message.split("\n").length - 2} commit message lines](${startCommandUri})`);
+        content.appendMarkdown(`$(git-commit)[See the other ${latestCommit.message.split("\n").length - 2} commit message lines](${startCommandUri})`);
         content.appendMarkdown(`\n\n`);
       }
       content.appendMarkdown(


### PR DESCRIPTION
## Description
Right now the context box has 2 problems:
- It's not clear that "Understand code context" is an action rather than an advertisement. 
- When the commit message has too many lines, Watermelon becomes obtrusive

This PR fixes these 2 issues. 

## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  
