### PR TITLE
Make the link look like a wm button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [1.5.2]
 
 - Will show the user a prompt to talk to the CTO every third use
+- The hover link will look more like a button
 
 ## [1.5.1]
 

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -38,9 +38,19 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
         )}`
       );
       const content = new vscode.MarkdownString(
-        `$(github-inverted)[ View the code context](${startCommandUri}) with Watermelon 🍉`
-        );
-      
+        `<table>
+          <tr>
+            <td>
+             <a style="color:#fff;background-color:#238636;" href="${startCommandUri}">
+                 <span style="color:#fff;background-color:#238636;">
+                  &nbsp;$(github-inverted)View the code context with Watermelon 🍉&nbsp;
+                </span> 
+              </a>
+             </td>
+           </tr>
+         </table>
+        `
+      );
       content.appendMarkdown(`\n\n`);
       content.appendMarkdown(
         `The latest commit was made by [$(mail)${
@@ -54,7 +64,11 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
       content.appendMarkdown(latestCommit.message.split("\n")[1] || "");
       content.appendMarkdown(`\n\n`);
       if (latestCommit.message.split("\n").length > 2) {
-        content.appendMarkdown(`$(git-commit)[See the other ${latestCommit.message.split("\n").length - 2} commit message lines](${startCommandUri})`);
+        content.appendMarkdown(
+          `$(git-commit)[See the other ${
+            latestCommit.message.split("\n").length - 2
+          } commit message lines](${startCommandUri})`
+        );
         content.appendMarkdown(`\n\n`);
       }
       content.appendMarkdown(

--- a/src/utils/components/hover.ts
+++ b/src/utils/components/hover.ts
@@ -43,7 +43,7 @@ const hover = ({ reporter }: { reporter: TelemetryReporter | null }) => {
             <td>
              <a style="color:#fff;background-color:#238636;" href="${startCommandUri}">
                  <span style="color:#fff;background-color:#238636;">
-                  &nbsp;$(github-inverted)View the code context with Watermelon 🍉&nbsp;
+                  <strong>&nbsp;$(github-inverted)View the code context with Watermelon 🍉&nbsp;</strong>
                 </span> 
               </a>
              </td>


### PR DESCRIPTION
## Description
The hover now shows more of a button.
## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  
## Notes
<!--  This is a great place to add images or possible improvements -->
<!--  Remember you can use "Closes #106" to close Issue 106 (or any number) -->
<img width="600" alt="Screen Shot 2022-08-25 at 11 46 49 AM" src="https://user-images.githubusercontent.com/11527621/186744431-ea41eb69-88d6-4d47-8976-eecffa762c85.png">

