### PR TITLE
Change telemetry key

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const GITHUB_AUTH_PROVIDER_ID = "github";
 //github scopes
 export const SCOPES = ["user:email", "repo", "read:org"];
 // telemetry insights key
-export const TELEMETRY_INSIGHTS_KEY = "4ed9e755-be2b-460b-9309-426fb5f58c6f";
+export const TELEMETRY_INSIGHTS_KEY = "bb2eac7f-33dd-426c-92c5-4dd922b2befb";
 // extension id
 export const EXTENSION_ID = "WatermelonTools.watermelon-tools";
 // Commands


### PR DESCRIPTION
## Description
We are moving our telemetry insights from my personal account to Watermelon's Azure account. This PR changes the instrumentation key to the one belonging to watermelonbackend's resource group. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [x] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
Starting November, the telemetry insights become company-wide accessible. 

Proof that it works (I'm in Son Tra, indeed). 
<img width="1012" alt="Screen Shot 2022-10-31 at 5 31 38 PM" src="https://user-images.githubusercontent.com/8325094/198988127-87172c55-5f25-4fa2-911e-92cb15cd7c38.png">


## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
